### PR TITLE
Fix support for `let` as an ES2015 identifer – additive

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -101,7 +101,10 @@ pp.parseMaybeAssign = function(noIn, refShorthandDefaultPos, afterLeftParse) {
     failOnShorthandAssign = false
   }
   let startPos = this.start, startLoc = this.startLoc
-  if (this.type == tt.parenL || this.type == tt.name)
+  if (this.type == tt.parenL ||
+      this.type == tt.name &&
+        !(this.isContextual("let") &&
+          this.isLexicalBinding(this.lookAhead())))
     this.potentialArrowAt = this.start
   let left = this.parseMaybeConditional(noIn, refShorthandDefaultPos)
   if (afterLeftParse) left = afterLeftParse.call(this, left, startPos, startLoc)
@@ -676,6 +679,7 @@ pp.parseComprehension = function(node, isGenerator) {
     let block = this.startNode()
     this.next()
     this.expect(tt.parenL)
+    if (this.isContextual("let") && this.isLexicalBinding(this.lookAhead())) this.unexpected()
     block.left = this.parseBindingAtom()
     this.checkLVal(block.left, true)
     this.expectContextual("of")

--- a/src/identifier.js
+++ b/src/identifier.js
@@ -23,7 +23,7 @@ var ecma5AndLessKeywords = "break case catch continue debugger default do else f
 
 export const keywords = {
   5: ecma5AndLessKeywords,
-  6: ecma5AndLessKeywords + " let const class extends export import yield super"
+  6: ecma5AndLessKeywords + " const class extends export import yield super"
 }
 
 // ## Character categories

--- a/src/loose/state.js
+++ b/src/loose/state.js
@@ -67,6 +67,17 @@ export class LooseParser {
     return dummy
   }
 
+  // Test whether the token can be the starting point of a LexicalBinding
+  // (BindingIdentifier or BindingPattern).
+
+  isLexicalBinding(tok) {
+    return this.options.ecmaVersion >= 6 &&
+             tok.type === tt.name ||
+          // tok.type === tt._yield ||
+             tok.type === tt.braceL ||
+             tok.type === tt.bracketL
+  }
+
   eat(type) {
     if (this.tok.type === type) {
       this.next()

--- a/src/parseutil.js
+++ b/src/parseutil.js
@@ -14,6 +14,17 @@ pp.isUseStrict = function(stmt) {
     stmt.expression.raw.slice(1, -1) === "use strict"
 }
 
+// Test whether the token can be the starting point of a LexicalBinding
+// (BindingIdentifier or BindingPattern).
+
+pp.isLexicalBinding = function(tok) {
+  return this.options.ecmaVersion >= 6 &&
+           tok.type === tt.name ||
+        // tok.type === tt._yield ||
+           tok.type === tt.braceL ||
+           tok.type === tt.bracketL
+}
+
 // Predicate that tests whether the next token is of the given
 // type, and if yes, consumes it as a side effect.
 

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -46,6 +46,64 @@ pp.getToken = function() {
   return new Token(this)
 }
 
+pp.saveState = function() {
+  return {
+    containsEsc: this.containsEsc,
+    lineStart: this.lineStart,
+    pos: this.pos,
+    curLine: this.curLine,
+    type: this.type,
+    value: this.value,
+    start: this.start,
+    end: this.end,
+    startLoc: this.startLoc,
+    endLoc: this.endLoc,
+    lastTokStart: this.lastTokStart,
+    lastTokEnd: this.lastTokEnd,
+    lastTokStartLoc: this.lastTokStartLoc,
+    lastTokEndLoc: this.lastTokEndLoc,
+    context: this.context.slice(),
+    exprAllowed: this.exprAllowed,
+    strict: this.strict,
+    potentialArrowAt: this.potentialArrowAt,
+    inGenerator: this.inGenerator,
+    inFunction: this.inFunction
+  }
+}
+
+pp.restoreState = function(old) {
+  this.containsEsc = old.containsEsc
+  this.lineStart = old.lineStart
+  this.pos = old.pos
+  this.curLine = old.curLine
+  this.type = old.type
+  this.value = old.value
+  this.start = old.start
+  this.end = old.end
+  this.startLoc = old.startLoc
+  this.endLoc = old.endLoc
+  this.lastTokStart = old.lastTokStart
+  this.lastTokEnd = old.lastTokEnd
+  this.lastTokStartLoc = old.lastTokStartLoc
+  this.lastTokEndLoc = old.lastTokEndLoc
+  this.context = old.context
+  this.exprAllowed = old.exprAllowed
+  this.strict = old.strict
+  this.potentialArrowAt = old.potentialArrowAt
+  this.inGenerator = old.inGenerator
+  this.inFunction = old.inFunction
+}
+
+pp.lookAhead = function(n = 1) {
+  const old = this.saveState()
+  let out
+  while (n--) {
+    out = this.getToken()
+  }
+  this.restoreState(old)
+  return out
+}
+
 // If we're in an ES6 environment, make parsers iterable
 if (typeof Symbol !== "undefined")
   pp[Symbol.iterator] = function () {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15434,17 +15434,6 @@ test("var await = 0", {
     {
       type: "VariableDeclaration",
       start: 0,
-      end: 13,
-      loc: {
-        start: {
-          line: 1,
-          column: 0
-        },
-        end: {
-          line: 1,
-          column: 13
-        }
-      },
       declarations: [
         {
           type: "VariableDeclarator",
@@ -15505,9 +15494,160 @@ test("var await = 0", {
   allowReserved: false,
   locations: true
 })
+
 testFail("var await = 0", "The keyword 'await' is reserved (1:4)", {
   ecmaVersion: 6,
   sourceType: "module",
   allowReserved: false,
   locations: true
 })
+
+// https://github.com/marijnh/acorn/issues/227
+
+test("let", {
+  type: "Program",
+  start: 0,
+  end: 3,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 3,
+      expression: {
+        type: "Identifier",
+        start: 0,
+        end: 3,
+        name: "let"
+      }
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+test("let => 0", {
+  type: "Program",
+  start: 0,
+  end: 8,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 8,
+      expression: {
+        type: "ArrowFunctionExpression",
+        start: 0,
+        end: 8,
+        id: null,
+        generator: false,
+        expression: true,
+        params: [ { type: "Identifier", start: 0, end: 3, name: "let" } ],
+        body: { type: "Literal", start: 7, end: 8, value: 0, raw: "0" }
+      }
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+test("function let() {}", {
+  type: "Program",
+  start: 0,
+  end: 17,
+  body: [
+    {
+      type: "FunctionDeclaration",
+      start: 0,
+      end: 17,
+      id: { type: "Identifier", start: 9, end: 12, name: "let" },
+      generator: false,
+      expression: false,
+      params: [],
+      body: { type: "BlockStatement", start: 15, end: 17, body: [] }
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+test("for (let in obj);", {
+  type: "Program",
+  start: 0,
+  end: 17,
+  body: [
+    {
+      type: "ForInStatement",
+      start: 0,
+      end: 17,
+      left: { type: "Identifier", start: 5, end: 8, name: "let" },
+      right: { type: "Identifier", start: 12, end: 15, name: "obj" },
+      body: { type: "EmptyStatement", start: 16, end: 17 }
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+testFail("for (let of obj);", "Unexpected token (1:5)", { ecmaVersion: 6 })
+
+test("var let", {
+  type: "Program",
+  start: 0,
+  end: 7,
+  body: [
+    {
+      type: "VariableDeclaration",
+      start: 0,
+      end: 7,
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 7
+        }
+      },
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          start: 4,
+          end: 7,
+          id: { type: "Identifier", start: 4, end: 7, name: "let" },
+          init: null
+        }
+      ],
+      kind: "var"
+    }
+  ],
+  sourceType: "script"
+}, {
+  ecmaVersion: 6,
+  sourceType: "script",
+  allowReserved: false,
+  locations: true
+})
+
+test("let of", {
+  type: "Program",
+  start: 0,
+  end: 6,
+  body: [
+    {
+      type: "VariableDeclaration",
+      start: 0,
+      end: 6,
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          start: 4,
+          end: 6,
+          id: { type: "Identifier", start: 4, end: 6, name: "of" },
+          init: null
+        }
+      ],
+      kind: "let"
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+testFail("const let = 0", "Unexpected token (1:6)", {ecmaVersion: 6})
+testFail("let let = 0", "Unexpected token (1:4)", {ecmaVersion: 6})


### PR DESCRIPTION
<del>**DO NOT MERGE!!!** This is a work-in-progress.</del> Not any more.

This PR is an alternative to #314. Fixes part of #227.

This works by starting with name tokens for all `let`s and then change qualifying tokens (namely those followed by a LexicalDeclaration) to a _let token. It is cleaner but may break some cases not covered by the test suite more easily than #314.

TODO:

- [x] Investigate why `[for (let x of []) x]` test is failing: `Expected error message: Unexpected token (1:6). Got error message: Unexpected token (1:10)`
- [x] Fix loose parser.