### PR TITLE
Add await as module reserved word

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -648,8 +648,7 @@ pp.parseIdent = function(liberal) {
   let node = this.startNode()
   if (liberal && this.options.allowReserved == "never") liberal = false
   if (this.type === tt.name) {
-    if (!liberal &&
-        (this.strict ? this.reservedWordsStrict : this.reservedWords).test(this.value) &&
+    if (!liberal && (this.strict ? this.reservedWordsStrict : this.reservedWords).test(this.value) &&
         (this.options.ecmaVersion >= 6 ||
          this.input.slice(this.start, this.end).indexOf("\\") == -1))
       this.raise(this.start, "The keyword '" + this.value + "' is reserved")

--- a/src/options.js
+++ b/src/options.js
@@ -91,7 +91,7 @@ export function getOptions(opts) {
   for (let opt in defaultOptions)
     options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt]
   if (options.allowReserved == null)
-    options.allowReserved = options.ecmaVersion >= 5
+    options.allowReserved = options.ecmaVersion < 5
 
   if (isArray(options.onToken)) {
     let tokens = options.onToken

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -33,6 +33,9 @@ if (typeof exports != "undefined") {
   var test = require("./driver.js").test;
   var testFail = require("./driver.js").testFail;
   var testAssert = require("./driver.js").testAssert;
+  var testOnly = require("./driver.js").testOnly;
+  var testFailOnly = require("./driver.js").testFailOnly;
+  var testAssertOnly = require("./driver.js").testAssertOnly;
 }
 
 /*
@@ -4324,6 +4327,8 @@ test("export var document = { }", {
   ranges: true,
   locations: true
 });
+
+testFail("export var await", "The keyword 'await' is reserved (1:11)", { ecmaVersion: 6, sourceType: "module" })
 
 test("export let document", {
   type: "Program",

--- a/test/tests.js
+++ b/test/tests.js
@@ -16363,6 +16363,66 @@ test("var x", {
   }
 });
 
+test("var await", {
+  type: "Program",
+  body: [
+    {
+      type: "VariableDeclaration",
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: "await",
+            loc: {
+              start: {
+                line: 1,
+                column: 4
+              },
+              end: {
+                line: 1,
+                column: 9
+              }
+            }
+          },
+          init: null,
+          loc: {
+            start: {
+              line: 1,
+              column: 4
+            },
+            end: {
+              line: 1,
+              column: 9
+            }
+          }
+        }
+      ],
+      kind: "var",
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 9
+        }
+      }
+    }
+  ],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 9
+    }
+  }
+});
+
 test("var x, y;", {
   type: "Program",
   body: [
@@ -27422,15 +27482,15 @@ testFail("throw\n10;", "Illegal newline after throw (1:5)");
 
 // ECMA < 6 mode should work as before
 
-testFail("const a;", "Unexpected token (1:6)");
+testFail("const a;", "The keyword 'const' is reserved (1:0)");
 
 testFail("let x;", "Unexpected token (1:4)");
 
-testFail("const a = 1;", "Unexpected token (1:6)");
+testFail("const a = 1;", "The keyword 'const' is reserved (1:0)");
 
 testFail("let a = 1;", "Unexpected token (1:4)");
 
-testFail("for(const x = 0;;);", "Unexpected token (1:10)");
+testFail("for(const x = 0;;);", "The keyword 'const' is reserved (1:4)");
 
 testFail("for(let x = 0;;);", "Unexpected token (1:8)");
 


### PR DESCRIPTION
This is a little bit hacky, so let me know if you'd prefer something else.

`await` is only a reserved word in modules *right now*, but if async functions are implemented for ES7, `await` would be a keyword in that context. So really, this restriction applies to modules running in ES6 mode or any other ES version that hasn't yet implemented async functions. In the future, that will mean checking for ES versions in addition to whether or not it's a module.

As a result, I'm calling the properties `strictModeES6Module` and `es6Module` in anticipation of async functions being added to ES7.

Fixes #326 
