### PR TITLE
Disallow yield as default parameters

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -13,7 +13,6 @@ pp.toAssignable = function(node, isBinding) {
     case "Identifier":
     case "ObjectPattern":
     case "ArrayPattern":
-    case "AssignmentPattern":
       break
 
     case "ObjectExpression":
@@ -34,10 +33,16 @@ pp.toAssignable = function(node, isBinding) {
       if (node.operator === "=") {
         node.type = "AssignmentPattern"
         delete node.operator
+        // falls through to AssignmentPattern
       } else {
         this.raise(node.left.end, "Only '=' operator can be used for specifying default value.")
+        break;
       }
-      break
+
+    case "AssignmentPattern":
+      if (node.right.type === "YieldExpression")
+        this.raise(node.right.start, "Yield expression cannot be a default value")
+      break;
 
     case "ParenthesizedExpression":
       node.expression = this.toAssignable(node.expression, isBinding)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -5923,6 +5923,9 @@ test("(function* () { yield yield 10 })", {
   locations: true
 });
 
+testFail("function *g() { (x = yield) => {} }", "Yield expression cannot be a default value (1:21)", { ecmaVersion: 6 })
+testFail("function *g() { ({x = yield}) => {} }", "Yield expression cannot be a default value (1:22)", { ecmaVersion: 6 })
+
 // Harmony: Iterators
 
 test("for(x of list) process(x);", {


### PR DESCRIPTION
Applies to both arrow functions and any function in strict mode.

Fixes #336