### PR TITLE
Allow CLI to read from STDIN

### DIFF
--- a/src/bin/acorn.js
+++ b/src/bin/acorn.js
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
 
 import {basename} from "path"
-import {readFileSync as read} from "fs"
+import {readSync as read, readFileSync as readFile} from "fs"
 import * as acorn from "../dist/acorn.js"
 
-let infile, parsed, tokens, silent = false, compact = false, tokenize = false
+let infile, forceFile, parsed, tokens, silent = false, compact = false, tokenize = false
 const options = {}
 
 function help(status) {
   const print = (status == 0) ? console.log : console.error
   print("usage: " + basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6]")
-  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] infile")
+  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] [infile]")
   process.exit(status)
 }
 
 for (let i = 2; i < process.argv.length; ++i) {
   const arg = process.argv[i]
-  if (arg[0] != "-" && !infile) infile = arg
-  else if (arg == "--" && !infile && i + 2 == process.argv.length) infile = process.argv[++i]
+  if ((arg == "-" || arg[0] != "-") && !infile) infile = arg
+  else if (arg == "--" && !infile && i + 2 == process.argv.length) forceFile = infile = process.argv[++i]
   else if (arg == "--ecma3") options.ecmaVersion = 3
   else if (arg == "--ecma5") options.ecmaVersion = 5
   else if (arg == "--ecma6") options.ecmaVersion = 6
@@ -33,7 +33,29 @@ for (let i = 2; i < process.argv.length; ++i) {
 }
 
 try {
-  const code = read(infile, "utf8")
+  let code = ""
+  if (forceFile || infile && infile != "-") code = readFile(infile, "utf8")
+  else {
+    // Read synchronously until running out of input
+    // See http://stackoverflow.com/a/16048083
+    const bufferSize = 4096
+    let bytesRead, buffer = new Buffer(bufferSize)
+    while (true) {
+      bytesRead = 0
+      try {
+        bytesRead = read(process.stdin.fd, buffer, 0, bufferSize)
+      } catch(e) {
+        // Honor end of input
+        if (e.code == "EOF") break
+
+        // Rethrow other errors, but provide a specific message if possible
+        if (e.code == "EAGAIN") console.error("Interactive input not supported")
+        throw e
+      }
+      if (bytesRead == 0) break
+      code += buffer.toString(null, 0, bytesRead)
+    }
+  }
 
   if (!tokenize)
     parsed = acorn.parse(code, options)


### PR DESCRIPTION
Makes the input file optional (defaulting to standard input), and allows `-` to explicitly represent standard input.

Example invocations:
```sh
$ echo '"use\x20strict"' | bin/acorn -
{
  "type": "Program",
  "start": 0,
  "end": 16,
  "body": [
    {
      "type": "ExpressionStatement",
      "start": 0,
      "end": 15,
      "expression": {
        "type": "Literal",
        "start": 0,
        "end": 15,
        "value": "use strict",
        "raw": "\"use\\x20strict\""
      }
    }
  ]
}
$ bin/acorn <<EOF
("use strict")
EOF
```