### PR TITLE
Add plugin support to loose parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Acorn
 
 [![Build Status](https://travis-ci.org/ternjs/acorn.svg?branch=master)](https://travis-ci.org/ternjs/acorn)
-[![NPM version](https://img.shields.io/npm/v/acorn.svg)](https://www.npmjs.org/package/acorn)  
+[![NPM version](https://img.shields.io/npm/v/acorn.svg)](https://www.npmjs.org/package/acorn)
 [Author funding status: ![maintainer happiness](https://marijnhaverbeke.nl/fund/status_s.png?force)](https://marijnhaverbeke.nl/fund/)
 
 A tiny, fast JavaScript parser, written completely in JavaScript.
@@ -379,5 +379,18 @@ parser.extend("readToken", function(nextMethod) {
 The `nextMethod` argument passed to `extend`'s second argument is the
 previous value of this method, and should usually be called through to
 whenever the extended method does not handle the call itself.
+
+Similarly, the loose parser allows plugins to register themselves via
+`acorn.pluginsLoose`.  The extension mechanism is the same as for the
+normal parser:
+
+```javascript
+looseParser.extend("readToken", function(nextMethod) {
+  return function() {
+    console.log("Reading a token in the loose parser!")
+    return nextMethod.call(this)
+  }
+})
+```
 
 There is a proof-of-concept JSX plugin in the [`acorn-jsx`](https://github.com/RReverser/acorn-jsx) project.

--- a/src/loose/index.js
+++ b/src/loose/index.js
@@ -30,12 +30,12 @@
 // tangle.
 
 import * as acorn from ".."
-import {LooseParser} from "./state"
+import {LooseParser, pluginsLoose} from "./state"
 import "./tokenize"
 import "./statement"
 import "./expression"
 
-export {LooseParser} from "./state"
+export {LooseParser, pluginsLoose} from "./state"
 
 acorn.defaultOptions.tabSize = 4
 
@@ -47,3 +47,4 @@ export function parse_dammit(input, options) {
 
 acorn.parse_dammit = parse_dammit
 acorn.LooseParser = LooseParser
+acorn.pluginsLoose = pluginsLoose

--- a/src/loose/state.js
+++ b/src/loose/state.js
@@ -1,5 +1,8 @@
 import {tokenizer, SourceLocation, tokTypes as tt, Node, lineBreak, isNewLine} from ".."
 
+// Registered plugins
+export const pluginsLoose = {}
+
 export class LooseParser {
   constructor(input, options) {
     this.toks = tokenizer(input, options)
@@ -15,6 +18,9 @@ export class LooseParser {
     this.curIndent = 0
     this.curLineStart = 0
     this.nextLineStart = this.lineEnd(this.curLineStart) + 1
+    // Load plugins
+    this.options.pluginsLoose = options.pluginsLoose || {}
+    this.loadPlugins(this.options.pluginsLoose)
   }
 
   startNode() {
@@ -138,5 +144,17 @@ export class LooseParser {
       if (ch !== 9 && ch !== 32) return false
     }
     return true
+  }
+
+  extend(name, f) {
+    this[name] = f(this[name])
+  }
+
+  loadPlugins(pluginConfigs) {
+    for (let name in pluginConfigs) {
+      let plugin = pluginsLoose[name]
+      if (!plugin) throw new Error("Plugin '" + name + "' not found")
+      plugin(this, pluginConfigs[name])
+    }
   }
 }


### PR DESCRIPTION
In response to #339. Adds the same plugin support to the loose parser as for the main acorn parser.

As a side note, the Eclipse CDT project implementing Qt requires that the loose parser be implemented for similar reasons to @angelozerr. We're trying to parse QML using acorn with promising results, but need to modify the loose parser so that we can perform static analysis properly with tern, which is where this pull request comes in.  :)