### PR TITLE
Disallow rest element as parameter in setter

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -510,6 +510,8 @@ pp.parsePropertyValue = function(prop, isPattern, isGenerator, startPos, startLo
         else
           this.raise(start, "setter should have exactly one param")
       }
+      if (prop.kind === "set" && prop.value.params[0].type === "RestElement")
+        this.raise(prop.value.params[0].start, "Setter cannot use rest params")
     } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
       prop.kind = "init"
       if (isPattern) {

--- a/src/statement.js
+++ b/src/statement.js
@@ -468,6 +468,8 @@ pp.parseClass = function(node, isStatement) {
         else
           this.raise(start, "setter should have exactly one param")
       }
+      if (method.kind === "set" && method.value.params[0].type === "RestElement")
+        this.raise(method.value.params[0].start, "Setter cannot use rest params")
     }
   }
   node.body = this.finishNode(classBody, "ClassBody")

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -11189,6 +11189,8 @@ test("(function x({ a, b }){})", {
 });
 
 testFail("(function x(...[ a, b ]){})", "Unexpected token (1:15)", {ecmaVersion: 6});
+testFail("var a = { set foo(...v) {} };", "Setter cannot use rest params (1:18)", {ecmaVersion: 6});
+testFail("class a { set foo(...v) {} };", "Setter cannot use rest params (1:18)", {ecmaVersion: 6});
 
 testFail("(function x({ a: { w, x }, b: [y, z] }, ...[a, b, c]){})", "Unexpected token (1:43)", {ecmaVersion: 6});
 


### PR DESCRIPTION
I wasn't sure if I should extract this logic out or not considering it exists in two places. Since there's other repeated logic in this regard, I opted not to, but let me know if you'd like me to.

Fixes #358 
