### PR TITLE
Disallow RegExp "y" flag in ES5 mode

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -410,8 +410,8 @@ pp.readRegexp = function() {
   let mods = this.readWord1()
   let tmp = content
   if (mods) {
-    let validFlags = /^[gmsiy]*$/
-    if (this.options.ecmaVersion >= 6) validFlags = /^[gmsiyu]*$/
+    let validFlags = /^[gim]*$/
+    if (this.options.ecmaVersion >= 6) validFlags = /^[gimuy]*$/
     if (!validFlags.test(mods)) this.raise(start, "Invalid regular expression flag")
     if (mods.indexOf('u') >= 0 && !regexpUnicodeSupport) {
       // Replace each astral symbol and every Unicode escape sequence that

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -14799,3 +14799,22 @@ testFail("var await = 0", "The keyword 'await' is reserved (1:4)", {
   allowReserved: false,
   locations: true
 })
+
+// https://github.com/ternjs/acorn/issues/363
+
+test("/[a-z]/gimuy", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "Literal",
+        regex: {
+          pattern: "[a-z]",
+          flags: "gimuy"
+        }
+      }
+    }
+  ]
+}, {ecmaVersion: 6});
+testFail("/[a-z]/s", "Invalid regular expression flag (1:1)", {ecmaVersion: 6});

--- a/test/tests.js
+++ b/test/tests.js
@@ -29090,3 +29090,25 @@ testAssert("[1,2,] + {foo: 1,}", function() {
 testFail("({ get prop(x) {} })", "getter should have no params (1:11)");
 testFail("({ set prop() {} })", "setter should have exactly one param (1:11)");
 testFail("({ set prop(x, y) {} })", "setter should have exactly one param (1:11)");
+
+// https://github.com/ternjs/acorn/issues/363
+
+test("/[a-z]/gim", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "Literal",
+        value: /[a-z]/gim,
+        regex: {
+          pattern: "[a-z]",
+          flags: "gim"
+        }
+      }
+    }
+  ]
+});
+testFail("/[a-z]/u", "Invalid regular expression flag (1:1)");
+testFail("/[a-z]/y", "Invalid regular expression flag (1:1)");
+testFail("/[a-z]/s", "Invalid regular expression flag (1:1)");


### PR DESCRIPTION
Previously, a regular expression with the "y" flag set would correctly parse in ES5 mode, though the "y" flag was first introduced in ES6. This change:

- Only permits the "y" flag when `ecmaVersion` is 6.
- Adds tests to verify that "u" and "y" (both new in ES6) fail to parse when `ecmaVersion` is less than 6.

An "s" flag is allowed in both ES5 and ES6 mode, though neither specification includes it. I left this as-is.

Currently the warning message for invalid regular expression flags gives the location as the start of the regular expression. It may be more helpful to give the location of the invalid flag, but I left this as-is for now.

ES5 spec text: http://www.ecma-international.org/ecma-262/5.1/#sec-15.10.4.1
ES6 spec text: http://www.ecma-international.org/ecma-262/6.0/#sec-regexpinitialize

Fixes #363