### PR TITLE
Fix: reserved words (fixes #365)

### DIFF
--- a/src/identifier.js
+++ b/src/identifier.js
@@ -9,10 +9,12 @@
 
 // Reserved word lists for various dialects of the language
 
+let ecma5ReservedWords = "break case catch class const continue debugger default delete do else enum export extends false finally for function if import in instanceof new null return super switch this throw true try typeof var void while with"
+
 export const reservedWords = {
-  3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
-  5: "class enum extends super const export import",
-  6: "enum",
+  3: "abstract boolean break byte case catch char class const continue debugger default delete do double else enum export extends false final finally float for function goto if implements import in instanceof int interface long native new null package private protected public return short static super switch synchronized this throw throws transient true try typeof var void volatile while with",
+  5: ecma5ReservedWords,
+  6: ecma5ReservedWords + " yield",
   strict: "implements interface let package private protected public static yield",
   strictBind: "eval arguments"
 }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -5414,6 +5414,11 @@ test("import * as crypto from \"crypto\"", {
   locations: true
 });
 
+testFail("import { class } from 'foo'", "Binding class in strict mode (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { class, var } from 'foo'", "Binding class in strict mode (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { a as class } from 'foo'", "Unexpected token (1:14)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import * as class from 'foo'", "Unexpected token (1:12)", {ecmaVersion: 6, sourceType: "module" });
+
 // Harmony: Yield Expression
 
 test("(function* () { yield v })", {


### PR DESCRIPTION
Fixes #365

https://github.com/ternjs/acorn/blob/master/src/statement.js#L616
https://github.com/ternjs/acorn/blob/master/src%2Flval.js#L175

`parseImportSpecifiers` seems to be checking whether or not the identifier is a reserved word. But `class` is not being handled as a reserved word.

https://github.com/ternjs/acorn/blob/master/src/identifier.js#L13-L15

The cause is that if `ecmaVersion` is 6, reserved words are only `enum`.
So I modified the definition of reserved words correctly.

But I see the message of `checkLVal`, the purpose of this method might be different from this PR's purpose.