### PR TITLE
Fix: checks imported variable name are not a keyword

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -612,7 +612,13 @@ pp.parseImportSpecifiers = function() {
 
     let node = this.startNode()
     node.imported = this.parseIdent(true)
-    node.local = this.eatContextual("as") ? this.parseIdent() : node.imported
+    if (this.eatContextual("as")) {
+      node.local = this.parseIdent()
+    } else {
+      node.local = node.imported
+      if (this.isKeyword(node.local.name)) this.unexpected(node.local.start)
+      if (this.reservedWordsStrict.test(node.local.name)) this.raise(node.local.start, "The keyword '" + node.local.name + "' is reserved")
+    }
     this.checkLVal(node.local, true)
     nodes.push(this.finishNode(node, "ImportSpecifier"))
   }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -5414,6 +5414,14 @@ test("import * as crypto from \"crypto\"", {
   locations: true
 });
 
+testFail("import { class } from 'foo'", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { class, var } from 'foo'", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { a as class } from 'foo'", "Unexpected token (1:14)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import * as class from 'foo'", "Unexpected token (1:12)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { enum } from 'foo'", "The keyword 'enum' is reserved (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import { a as enum } from 'foo'", "The keyword 'enum' is reserved (1:14)", {ecmaVersion: 6, sourceType: "module" });
+testFail("import * as enum from 'foo'", "The keyword 'enum' is reserved (1:12)", {ecmaVersion: 6, sourceType: "module" });
+
 // Harmony: Yield Expression
 
 test("(function* () { yield v })", {


### PR DESCRIPTION
Fixes #365

This approach throws the same error (`Unexpected token`) as the case that there is `as` token.