### PR TITLE
Disallow `\00` and `\000` escapes in strict mode.

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -617,7 +617,7 @@ pp.readEscapedChar = function(inTemplate) {
         octalStr = octalStr.slice(0, -1)
         octal = parseInt(octalStr, 8)
       }
-      if (octal > 0 && (this.strict || inTemplate)) {
+      if (octalStr !== "0" && (this.strict || inTemplate)) {
         this.raise(this.pos - 2, "Octal literal in strict mode")
       }
       this.pos += octalStr.length - 1

--- a/test/tests.js
+++ b/test/tests.js
@@ -26669,6 +26669,9 @@ test("price_9̶9̶_89", {
   ]
 });
 
+// `\0` is valid even in strict mode
+test("function hello() { 'use strict'; \"\\0\"; }", {});
+
 // option tests
 
 test("var a = 1;", {
@@ -27404,6 +27407,12 @@ testFail("function hello() { 'use strict'; function inner(arguments) {} }",
          "Binding arguments in strict mode (1:48)");
 
 testFail("function hello() { 'use strict'; \"\\1\"; }",
+         "Octal literal in strict mode (1:34)");
+
+testFail("function hello() { 'use strict'; \"\\00\"; }",
+         "Octal literal in strict mode (1:34)");
+
+testFail("function hello() { 'use strict'; \"\\000\"; }",
          "Octal literal in strict mode (1:34)");
 
 testFail("function hello() { 'use strict'; 021; }",


### PR DESCRIPTION
Cf. https://github.com/tc39/test262/blob/master/test/language/literals/string/7.8.4-5-s.js