### PR TITLE
Add raiseRecoverable hook

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -17,6 +17,8 @@ pp.raise = function(pos, message) {
   throw err
 }
 
+pp.raiseRecoverable = pp.raise;
+
 pp.curPosition = function() {
   if (this.options.locations) {
     return new Position(this.curLine, this.pos - this.lineStart)

--- a/src/lval.js
+++ b/src/lval.js
@@ -173,16 +173,16 @@ pp.checkLVal = function(expr, isBinding, checkClashes) {
   switch (expr.type) {
   case "Identifier":
     if (this.strict && this.reservedWordsStrictBind.test(expr.name))
-      this.raise(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
+      this.raiseRecoverable(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
     if (checkClashes) {
       if (has(checkClashes, expr.name))
-        this.raise(expr.start, "Argument name clash")
+        this.raiseRecoverable(expr.start, "Argument name clash")
       checkClashes[expr.name] = true
     }
     break
 
   case "MemberExpression":
-    if (isBinding) this.raise(expr.start, (isBinding ? "Binding" : "Assigning to") + " member expression")
+    if (isBinding) this.raiseRecoverable(expr.start, (isBinding ? "Binding" : "Assigning to") + " member expression")
     break
 
   case "ObjectPattern":

--- a/src/statement.js
+++ b/src/statement.js
@@ -240,7 +240,7 @@ pp.parseSwitchStatement = function(node) {
       if (isCase) {
         cur.test = this.parseExpression()
       } else {
-        if (sawDefault) this.raise(this.lastTokStart, "Multiple default clauses")
+        if (sawDefault) this.raiseRecoverable(this.lastTokStart, "Multiple default clauses")
         sawDefault = true
         cur.test = null
       }
@@ -490,9 +490,9 @@ pp.parseClass = function(node, isStatement) {
       if (method.value.params.length !== paramCount) {
         let start = method.value.start
         if (method.kind === "get")
-          this.raise(start, "getter should have no params")
+          this.raiseRecoverable(start, "getter should have no params")
         else
-          this.raise(start, "setter should have exactly one param")
+          this.raiseRecoverable(start, "setter should have exactly one param")
       }
       if (method.kind === "set" && method.value.params[0].type === "RestElement")
         this.raise(method.value.params[0].start, "Setter cannot use rest params")


### PR DESCRIPTION
This allows consumers to override raiseRecoverable() errors if they want.
To start, I only added this in places where value validation failed.

Fixes #370