### PR TITLE
Add support for ** under ecmaVersion 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object referring to that same position.
 [estree]: https://github.com/estree/estree
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
-  either 3, 5, or 6. This influences support for strict mode, the set
+  either 3, 5, 6, or 7. This influences support for strict mode, the set
   of reserved words, and support for new syntax features. Default is 5.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
@@ -304,7 +304,7 @@ The `bin/acorn` utility can be used to parse a file from the command
 line. It accepts as arguments its input file and the following
 options:
 
-- `--ecma3|--ecma5|--ecma6`: Sets the ECMAScript version to parse. Default is
+- `--ecma3|--ecma5|--ecma6|--ecma7`: Sets the ECMAScript version to parse. Default is
   version 5.
 
 - `--module`: Sets the parsing mode to `"module"`. Is set to `"script"` otherwise.

--- a/src/bin/acorn.js
+++ b/src/bin/acorn.js
@@ -9,7 +9,7 @@ const options = {}
 
 function help(status) {
   const print = (status == 0) ? console.log : console.error
-  print("usage: " + basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6]")
+  print("usage: " + basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6|--ecma7]")
   print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] [infile]")
   process.exit(status)
 }
@@ -21,6 +21,7 @@ for (let i = 2; i < process.argv.length; ++i) {
   else if (arg == "--ecma3") options.ecmaVersion = 3
   else if (arg == "--ecma5") options.ecmaVersion = 5
   else if (arg == "--ecma6") options.ecmaVersion = 6
+  else if (arg == "--ecma7") options.ecmaVersion = 7
   else if (arg == "--locations") options.locations = true
   else if (arg == "--allow-hash-bang") options.allowHashBang = true
   else if (arg == "--silent") silent = true

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -228,10 +228,20 @@ pp.readToken_slash = function() { // '/'
   return this.finishOp(tt.slash, 1)
 }
 
-pp.readToken_mult_modulo = function(code) { // '%*'
+pp.readToken_mult_modulo_exp = function(code) { // '%*'
   let next = this.input.charCodeAt(this.pos + 1)
-  if (next === 61) return this.finishOp(tt.assign, 2)
-  return this.finishOp(code === 42 ? tt.star : tt.modulo, 1)
+  let size = 1
+  let tokentype = code === 42 ? tt.star : tt.modulo
+
+  // exponentiation operator ** and **=
+  if (this.options.ecmaVersion >= 7 && next === 42) {
+    ++size
+    tokentype = tt.starstar
+    next = this.input.charCodeAt(this.pos + 2)
+  }
+
+  if (next === 61) return this.finishOp(tt.assign, size + 1)
+  return this.finishOp(tokentype, size)
 }
 
 pp.readToken_pipe_amp = function(code) { // '|&'
@@ -343,7 +353,7 @@ pp.getTokenFromCode = function(code) {
     return this.readToken_slash()
 
   case 37: case 42: // '%*'
-    return this.readToken_mult_modulo(code)
+    return this.readToken_mult_modulo_exp(code)
 
   case 124: case 38: // '|&'
     return this.readToken_pipe_amp(code)

--- a/src/tokentype.js
+++ b/src/tokentype.js
@@ -95,7 +95,8 @@ export const types = {
   plusMin: new TokenType("+/-", {beforeExpr: true, binop: 9, prefix: true, startsExpr: true}),
   modulo: binop("%", 10),
   star: binop("*", 10),
-  slash: binop("/", 10)
+  slash: binop("/", 10),
+  starstar: binop("**", 11)
 }
 
 // Map keyword names to token types.

--- a/test/run.js
+++ b/test/run.js
@@ -5,6 +5,7 @@
     driver = require("./driver.js");
     require("./tests.js");
     require("./tests-harmony.js");
+    require("./tests-es7.js");
     require("babel-core/register")
     acorn = require("../src")
     require("../src/loose")

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -1,0 +1,289 @@
+// Tests for ECMAScript 7 syntax changes
+
+if (typeof exports != "undefined") {
+  var test = require("./driver.js").test;
+  var testFail = require("./driver.js").testFail;
+}
+
+test("x **= 42", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "AssignmentExpression",
+        operator: "**=",
+        left: {
+          type: "Identifier",
+          name: "x",
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 1
+            }
+          }
+        },
+        right: {
+          type: "Literal",
+          value: 42,
+          loc: {
+            start: {
+              line: 1,
+              column: 6
+            },
+            end: {
+              line: 1,
+              column: 8
+            }
+          }
+        },
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 8
+          }
+        }
+      },
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 8
+        }
+      }
+    }
+  ],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 8
+    }
+  }
+}, {
+  ecmaVersion: 7,
+  locations: true
+});
+
+testFail("x **= 42", "Unexpected token (1:3)", { ecmaVersion: 6 });
+
+test("x ** y", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "BinaryExpression",
+        left: {
+          type: "Identifier",
+          name: "x",
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 1
+            }
+          }
+        },
+        operator: "**",
+        right: {
+          type: "Identifier",
+          name: "y",
+          loc: {
+            start: {
+              line: 1,
+              column: 5
+            },
+            end: {
+              line: 1,
+              column: 6
+            }
+          }
+        },
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 6
+          }
+        }
+      },
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 6
+        }
+      }
+    }
+  ],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 6
+    }
+  }
+}, {
+  ecmaVersion: 7,
+  locations: true
+});
+
+testFail("x ** y", "Unexpected token (1:3)", { ecmaVersion: 6 });
+
+// ** has highest precedence
+test("3 ** 5 * 1", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "BinaryExpression",
+        operator: "*",
+        left: {
+          type: "BinaryExpression",
+          operator: "**",
+          left: {
+            type: "Literal",
+            value: 3
+          },
+          right: {
+            type: "Literal",
+            value: 5
+          }
+        },
+        right: {
+          type: "Literal",
+          value: 1
+        }
+      }
+    }
+  ]
+}, {
+  ecmaVersion: 7,
+});
+
+test("3 % 5 ** 1", {
+  type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "BinaryExpression",
+          operator: "%",
+          left: {
+            type: "Literal",
+            value: 3
+          },
+          right: {
+            type: "BinaryExpression",
+            operator: "**",
+            left: {
+              type: "Literal",
+              value: 5
+            },
+            right: {
+              type: "Literal",
+              value: 1
+            }
+          }
+        }
+      }
+    ]
+}, {
+  ecmaVersion: 7,
+});
+
+testFail("x ** y", "Unexpected token (1:3)", { ecmaVersion: 6 });
+
+// Disallowed unary ops
+testFail("delete o.p ** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("void 2 ** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("typeof 2 ** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("~3 ** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("!1 ** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("-2** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+testFail("+2** 2;", "Base operand of ** cannot use a unary expression (1:0)", { ecmaVersion: 7 });
+
+// make sure base operand check doesn't affect other operators
+test("-a * 5", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "BinaryExpression",
+        left: {
+          type: "UnaryExpression",
+          operator: "-",
+          prefix: true,
+          argument: {
+            type: "Identifier",
+            name: "a"
+          }
+        },
+        operator: "*",
+        right: {
+          type: "Literal",
+          value: 5,
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, { ecmaVersion: 6 })
+
+
+test("(-5) ** y", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "BinaryExpression",
+        left: {
+          type: "UnaryExpression",
+          operator: "-",
+          prefix: true,
+          argument: {
+            type: "Literal",
+            value: 5
+          }
+        },
+        operator: "**",
+        right: {
+          type: "Identifier",
+          name: "y"
+        }
+      }
+    }
+  ]
+}, {
+  ecmaVersion: 7
+});


### PR DESCRIPTION
This adds support for the exponentiation operator, which is currently Stage 4 for ES7. The supported operators are ** and **=.

Fixes #381 

I wasn't sure what additional doc changes you'd like besides the ones I made here, but let me know and I'll update it.