### PR TITLE
docs: ES6 is now the default in `options.ecmaVersion`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ object referring to that same position.
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
   either 3, 5, 6, or 7. This influences support for strict mode, the set
-  of reserved words, and support for new syntax features. Default is 5.
+  of reserved words, and support for new syntax features. Default is 6.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   either `"script"` or `"module"`.


### PR DESCRIPTION
As per https://github.com/ternjs/acorn/blob/bed00427b5b3b3be57abef555ef1c466fc493f5b/src/options.js#L12, default is now ES6