### PR TITLE
Make visitors with Object.create

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -143,8 +143,7 @@ export function findNodeBefore(node, pos, test, base, state) {
 // type properties with the defaults.
 export function make(funcs, base) {
   if (!base) base = exports.base
-  let visitor = {}
-  for (var type in base) visitor[type] = base[type]
+  let visitor = Object.create(base)
   for (var type in funcs) visitor[type] = funcs[type]
   return visitor
 }

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -139,11 +139,22 @@ export function findNodeBefore(node, pos, test, base, state) {
   return max
 }
 
+// Fallback to an Object.create polyfill for older environments.
+const create = Object.create ? Object.create : (() => {
+  let Temp = function() {}
+  return function(prototype) {
+    Temp.prototype = prototype
+    let result = new Temp()
+    Temp.prototype = null
+    return result
+  }
+})()
+
 // Used to create a custom walker. Will fill in all missing node
 // type properties with the defaults.
 export function make(funcs, base) {
   if (!base) base = exports.base
-  let visitor = Object.create(base)
+  let visitor = create(base)
   for (var type in funcs) visitor[type] = funcs[type]
   return visitor
 }


### PR DESCRIPTION
This makes it so visitors are retroactively extensible by adding new node types to `exports.base`. That seems reasonable, given that it was also possible to extend node type support by mutating `exports.base` prior to calling `walk.make`.

This solves a problem in Tern where we wanted to extend all walkers to support JSX syntax. See https://github.com/ternjs/tern/pull/746.

This could potentially break code that does a `visitor.hasOwnProperty('SomeDefaultNodeType')` check. Such code would have to do the check like this, instead: `visitor['SomeDefaultNodeType']`. If that concerns you, then maybe we could expose another object to be the prototype of an object with node type handlers as own properties (like we have now), and that exposed prototype object could be the extensible bit:

```js
 export const extensions = {}

 export function make(funcs, base) {
   if (!base) base = exports.base
   let visitor = Object.create(exports.extensions)
   for (var type in base) visitor[type] = base[type]
   for (var type in funcs) visitor[type] = funcs[type]
   return visitor
 }
```

Let me know what'd you like. Thanks!