### PR TITLE
Implements ES2016 check for "use strict"

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -607,25 +607,29 @@ pp.parseFunctionBody = function(node, isArrowFunction) {
   // If this is a strict mode function, verify that argument names
   // are not repeated, and it does not try to bind the words `eval`
   // or `arguments`.
-  if (this.strict || !isExpression && node.body.body.length && this.isUseStrict(node.body.body[0])) {
+  let refUseStrict = (!isExpression && node.body.body.length && this.isUseStrict(node.body.body[0])) ? node.body.body[0] : null;
+  if (this.strict || refUseStrict) {
     let oldStrict = this.strict
     this.strict = true
     if (node.id)
       this.checkLVal(node.id, true)
-    this.checkParams(node)
+    this.checkParams(node, refUseStrict)
     this.strict = oldStrict
   } else if (isArrowFunction) {
-    this.checkParams(node)
+    this.checkParams(node, refUseStrict)
   }
 }
 
 // Checks function params for various disallowed patterns such as using "eval"
 // or "arguments" and duplicate parameters.
 
-pp.checkParams = function(node) {
+pp.checkParams = function(node, refUseStrict) {
     let nameHash = {}
-    for (let i = 0; i < node.params.length; i++)
+    for (let i = 0; i < node.params.length; i++) {
+      if (node.params.type !== "Identifier" && refUseStrict && this.options.ecmaVersion >= 7)
+        this.raiseRecoverable(refUseStrict.start, "Illegal 'use strict' directive in function with non-simple parameter list");
       this.checkLVal(node.params[i], true, nameHash)
+    }
 }
 
 // Parses a comma-separated list of expressions, and returns them as

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -343,3 +343,8 @@ test("a-- ** 2", {
   ],
   "sourceType": "script"
 }, {ecmaVersion: 7})
+
+testFail("function foo(a=2) { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:20)", { ecmaVersion: 7 })
+testFail("(a=2) => { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:11)", { ecmaVersion: 7 })
+testFail("function foo({a}) { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:20)", { ecmaVersion: 7 })
+testFail("({a}) => { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:11)", { ecmaVersion: 7 })

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -9150,6 +9150,98 @@ test("function f([x] = [1]) {}", {
   locations: true
 });
 
+test("function f([x] = [1]) { 'use strict' }", {
+  type: "Program",
+  body: [{
+    type: "FunctionDeclaration",
+    id: {
+      type: "Identifier",
+      name: "f",
+      loc: {
+        start: {line: 1, column: 9},
+        end: {line: 1, column: 10}
+      }
+    },
+    params: [{
+      type: "AssignmentPattern",
+      left: {
+        type: "ArrayPattern",
+        elements: [{
+          type: "Identifier",
+          name: "x",
+          loc: {
+            start: {line: 1, column: 12},
+            end: {line: 1, column: 13}
+          }
+        }],
+        loc: {
+          start: {line: 1, column: 11},
+          end: {line: 1, column: 14}
+        }
+      },
+      right: {
+        type: "ArrayExpression",
+        elements: [{
+          type: "Literal",
+          value: 1,
+          raw: "1",
+          loc: {
+            start: {line: 1, column: 18},
+            end: {line: 1, column: 19}
+          }
+        }],
+        loc: {
+          start: {line: 1, column: 17},
+          end: {line: 1, column: 20}
+        }
+      },
+      loc: {
+        start: {line: 1, column: 11},
+        end: {line: 1, column: 20}
+      }
+    }],
+    body: {
+      type: "BlockStatement",
+      body: [
+        {
+          type: "ExpressionStatement",
+          loc: {
+            start: {line: 1, column: 24},
+            end: {line: 1, column: 36}
+          },
+          expression: {
+            type: "Literal",
+            loc: {
+              start: {line: 1, column: 24},
+              end: {line: 1, column: 36}
+            },
+            value: "use strict",
+            raw: "'use strict'"
+          }
+        }
+      ],
+      loc: {
+        start: {line: 1, column: 22},
+        end: {line: 1, column: 38}
+      }
+    },
+    generator: false,
+    expression: false,
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 38}
+    }
+  }],
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 38}
+  }
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+});
+
 test("function f({x} = {x: 10}) {}", {
   type: "Program",
   body: [{


### PR DESCRIPTION
In ES2016, you can no longer have "use strict" in the body of a function
that has complex parameters (destructured or using default values).

Fixes #423