### PR TITLE
Fix handling of `[,]` in toAssignableList.

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -75,7 +75,7 @@ pp.toAssignableList = function(exprList, isBinding) {
       --end
     }
 
-    if (isBinding && last.type === "RestElement" && last.argument.type !== "Identifier")
+    if (isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier")
       this.unexpected(last.argument.start)
   }
   for (let i = 0; i < end; i++) {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -14448,3 +14448,22 @@ test("/[a-z]/gimuy", {
 testFail("/[a-z]/s", "Invalid regular expression flag (1:1)", {ecmaVersion: 6});
 
 testFail("[...x in y] = []", "Assigning to rvalue (1:4)", {ecmaVersion: 6});
+
+test("(([,]) => 0)", {
+  type: "Program",
+  body: [{
+    type: "ExpressionStatement",
+    expression: {
+      type: "ArrowFunctionExpression",
+      params: [{
+        type: "ArrayPattern",
+        elements: [null]
+      }],
+      body: {
+        type: "Literal",
+        value: 0,
+        raw: "0"
+      }
+    }
+  }]
+}, {ecmaVersion: 6});


### PR DESCRIPTION
This would previously cause a null dereference.