### PR TITLE
Clarify the expected values for ecmaVersion and make 7 the default

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -6,10 +6,10 @@ import {SourceLocation} from "./locutil"
 
 export const defaultOptions = {
   // `ecmaVersion` indicates the ECMAScript version to parse. Must
-  // be either 3, or 5, or 6. This influences support for strict
+  // be either 3, or 5, or 6, or 7. This influences support for strict
   // mode, the set of reserved words, support for getters and
-  // setters and other features. The default is 6.
-  ecmaVersion: 6,
+  // setters and other features. The default is 7.
+  ecmaVersion: 7,
   // Source type ("script" or "module") for different semantics
   sourceType: "script",
   // `onInsertedSemicolon` can be a callback that will be called


### PR DESCRIPTION
Since ecmaVersion 7 is the latest available value, the default value should be updated to that version. Also the documentation should state the expected values. This would make the new operator being accepted out of the box.
