### PR TITLE
Fix ES2016 check for "use strict".

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -626,7 +626,7 @@ pp.parseFunctionBody = function(node, isArrowFunction) {
 pp.checkParams = function(node, useStrict) {
     let nameHash = {}
     for (let i = 0; i < node.params.length; i++) {
-      if (useStrict && this.options.ecmaVersion >= 7 && node.params.type !== "Identifier")
+      if (useStrict && this.options.ecmaVersion >= 7 && node.params[i].type !== "Identifier")
         this.raiseRecoverable(useStrict.start, "Illegal 'use strict' directive in function with non-simple parameter list");
       this.checkLVal(node.params[i], true, nameHash)
     }

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -348,3 +348,4 @@ testFail("function foo(a=2) { 'use strict'; }", "Illegal 'use strict' directive 
 testFail("(a=2) => { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:11)", { ecmaVersion: 7 })
 testFail("function foo({a}) { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:20)", { ecmaVersion: 7 })
 testFail("({a}) => { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:11)", { ecmaVersion: 7 })
+test("function foo(a) { 'use strict'; }", {}, { ecmaVersion: 7 });


### PR DESCRIPTION
The check introduced in a062434d4ce5e771c3a44a89985f9cb6fa9a10a3 accidentally flags all `use strict` directives in functions in ES2016 mode.