### PR TITLE
Disallow parens-wrapped destructuring assignments

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -101,6 +101,7 @@ pp.parseMaybeAssign = function(noIn, refDestructuringErrors, afterLeftParse) {
   let startPos = this.start, startLoc = this.startLoc
   if (this.type == tt.parenL || this.type == tt.name)
     this.potentialArrowAt = this.start
+  let parens = this.type === tt.parenL
   let left = this.parseMaybeConditional(noIn, refDestructuringErrors)
   if (afterLeftParse) left = afterLeftParse.call(this, left, startPos, startLoc)
   if (this.type.isAssign) {
@@ -110,6 +111,10 @@ pp.parseMaybeAssign = function(noIn, refDestructuringErrors, afterLeftParse) {
     node.operator = this.value
     node.left = this.type === tt.eq ? this.toAssignable(left) : left
     refDestructuringErrors.shorthandAssign = 0 // reset because shorthand default was used correctly
+    if (parens && (node.left.type === "ObjectPattern" || node.left.type === "ArrayPattern"))
+      this.raise(node.left.start, "Wrapping parentheses are not allowed around destructuring patterns")
+    if (left.type === "AssignmentPattern")
+      this.raise(node.left.start, "Invalid left-hand side in assignment")
     this.checkLVal(left)
     this.next()
     node.right = this.parseMaybeAssign(noIn)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -3132,7 +3132,7 @@ test("[a, b] = [b, a]", {
   locations: true
 });
 
-test("({ responseText: text }) = res", {
+test("({ responseText: text } = res)", {
   type: "Program",
   body: [{
     type: "ExpressionStatement",
@@ -3177,13 +3177,13 @@ test("({ responseText: text }) = res", {
         type: "Identifier",
         name: "res",
         loc: {
-          start: {line: 1, column: 27},
-          end: {line: 1, column: 30}
+          start: {line: 1, column: 26},
+          end: {line: 1, column: 29}
         }
       },
       loc: {
-        start: {line: 1, column: 0},
-        end: {line: 1, column: 30}
+        start: {line: 1, column: 1},
+        end: {line: 1, column: 29}
       }
     },
     loc: {
@@ -3765,6 +3765,9 @@ test("var {a:b} = {}", {
   ranges: true,
   locations: true
 });
+
+testFail("({a}) = {}", "Wrapping parentheses are not allowed around destructuring patterns (1:1)", {ecmaVersion: 6})
+testFail("([a]) = []", "Wrapping parentheses are not allowed around destructuring patterns (1:1)", {ecmaVersion: 6})
 
 // Harmony: Modules
 
@@ -12779,9 +12782,9 @@ testFail("let default", "Unexpected token (1:4)", {ecmaVersion: 6});
 
 testFail("const default", "Unexpected token (1:6)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; ({ v: eval }) = obj", "Assigning to eval in strict mode (1:20)", {ecmaVersion: 6});
+testFail("\"use strict\"; ({ v: eval } = obj)", "Assigning to eval in strict mode (1:20)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; ({ v: arguments }) = obj", "Assigning to arguments in strict mode (1:20)", {ecmaVersion: 6});
+testFail("\"use strict\"; ({ v: arguments } = obj)", "Assigning to arguments in strict mode (1:20)", {ecmaVersion: 6});
 
 testFail("for (let x = 42 in list) process(x);", "Unexpected token (1:16)", {ecmaVersion: 6});
 
@@ -14559,3 +14562,7 @@ test("(([,]) => 0)", {
     }
   }]
 }, {ecmaVersion: 6});
+
+// https://github.com/ternjs/acorn/issues/255
+
+testFail("(a = b) = {};", "Invalid left-hand side in assignment (1:1)", {ecmaVersion: 6})

--- a/test/tests.js
+++ b/test/tests.js
@@ -29127,3 +29127,141 @@ test("/[a-z]/gim", {
 testFail("/[a-z]/u", "Invalid regular expression flag (1:1)");
 testFail("/[a-z]/y", "Invalid regular expression flag (1:1)");
 testFail("/[a-z]/s", "Invalid regular expression flag (1:1)");
+
+// https://github.com/ternjs/acorn/issues/255
+
+test("(a) = {}", {
+  type: "Program",
+  start: 0,
+  end: 8,
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 8}
+  },
+  range: [0, 8],
+  body: [{
+    type: "ExpressionStatement",
+    start: 0,
+    end: 8,
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 8}
+    },
+    range: [0, 8],
+    expression: {
+      type: "AssignmentExpression",
+      start: 0,
+      end: 8,
+      loc: {
+        start: {line: 1, column: 0},
+        end: {line: 1, column: 8}
+      },
+      range: [0, 8],
+      operator: "=",
+      left: {
+        type: "Identifier",
+        start: 1,
+        end: 2,
+        loc: {
+          start: {line: 1, column: 1},
+          end: {line: 1, column: 2}
+        },
+        range: [1, 2],
+        name: "a"
+      },
+      right: {
+        type: "ObjectExpression",
+        start: 6,
+        end: 8,
+        loc: {
+          start: {line: 1, column: 6},
+          end: {line: 1, column: 8}
+        },
+        range: [6, 8],
+        properties: []
+      }
+    }
+  }]
+}, {
+  ranges: true,
+  locations: true
+})
+
+test("(a.b) = {}", {
+  type: "Program",
+  start: 0,
+  end: 10,
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 10}
+  },
+  range: [0, 10],
+  body: [{
+    type: "ExpressionStatement",
+    start: 0,
+    end: 10,
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 10}
+    },
+    range: [0, 10],
+    expression: {
+      type: "AssignmentExpression",
+      start: 0,
+      end: 10,
+      loc: {
+        start: {line: 1, column: 0},
+        end: {line: 1, column: 10}
+      },
+      range: [0, 10],
+      operator: "=",
+      left: {
+        type: "MemberExpression",
+        start: 1,
+        end: 4,
+        loc: {
+          start: {line: 1, column: 1},
+          end: {line: 1, column: 4}
+        },
+        range: [1, 4],
+        object: {
+          type: "Identifier",
+          start: 1,
+          end: 2,
+          loc: {
+            start: {line: 1, column: 1},
+            end: {line: 1, column: 2}
+          },
+          range: [1, 2],
+          name: "a"
+        },
+        property: {
+          type: "Identifier",
+          start: 3,
+          end: 4,
+          loc: {
+            start: {line: 1, column: 3},
+            end: {line: 1, column: 4}
+          },
+          range: [3, 4],
+          name: "b"
+        },
+        computed: false
+      },
+      right: {
+        type: "ObjectExpression",
+        start: 8,
+        end: 10,
+        loc: {
+          start: {line: 1, column: 8},
+          end: {line: 1, column: 10}
+        },
+        range: [8, 10],
+        properties: []
+      }
+    }
+  }]
+}, {
+  ranges: true,
+  locations: true
+})


### PR DESCRIPTION
fixes #255

Thoughts on this approach? Thanks for the feedback!

**Added 7/11**: Realizing this logic gets bypassed for the `preserveParens` option. Will look more into that, but would appreciate any feedback in the meantime :)
