### PR TITLE
simplify rollup config using new `paths` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "acorn": "./bin/acorn"
   },
   "devDependencies": {
-    "rollup": "^0.31.2",
+    "rollup": "^0.34.1",
     "rollup-plugin-buble": "^0.11.0",
     "unicode-8.0.0": "^0.1.5"
   }

--- a/rollup/config.bin.js
+++ b/rollup/config.bin.js
@@ -1,40 +1,10 @@
-import buble from 'rollup-plugin-buble';
-import { dirname, resolve } from 'path';
-
-// this is a bit of a hack to trick Rollup into keeping the
-// correct relative path in the bundled output – probably
-// something Rollup itself should handle more smartly
-var FAKE_ACORN_DIST = resolve( 'src/dist/acorn.js' );
-
 export default {
 	entry: 'src/bin/acorn.js',
 	dest: 'bin/acorn',
 	format: 'cjs',
 	banner: '#!/usr/bin/env node',
-	plugins: [
-		{
-			resolveId: function ( importee, importer ) {
-				if ( !importer ) return;
-
-				// externalise acorn
-				var resolved = resolve( dirname( importer ), importee );
-				try {
-					var stats = statSync( resolved );
-					resolved = resolve( resolved, 'index.js' );
-				} catch ( err ) {
-					resolved += '.js';
-				}
-
-				if ( resolved === resolve( 'src/index.js' ) ) {
-					return FAKE_ACORN_DIST;
-				}
-			}
-		},
-		buble()
-	],
-	external: [
-		'fs',
-		'path',
-		FAKE_ACORN_DIST
-	]
+	external: [ 'fs', 'path', 'acorn' ],
+	paths: {
+		acorn: '../dist/acorn.js'
+	}
 };

--- a/rollup/config.loose.js
+++ b/rollup/config.loose.js
@@ -1,42 +1,15 @@
-import { dirname, resolve } from 'path';
-import { statSync } from 'fs';
-import buble from 'rollup-plugin-buble';
-
-// this is a bit of a hack to trick Rollup into keeping the
-// correct relative path in the bundled output – probably
-// something Rollup itself should handle more smartly
-var FAKE_ACORN_DIST = resolve( 'src/loose/acorn.js' );
-
 export default {
 	entry: 'src/loose/index.js',
 	moduleName: 'acorn.loose',
-	plugins: [
-		{
-			resolveId: function ( importee, importer ) {
-				if ( !importer ) return;
-
-				// externalise acorn
-				var resolved = resolve( dirname( importer ), importee );
-				try {
-					var stats = statSync( resolved );
-					resolved = resolve( resolved, 'index.js' );
-				} catch ( err ) {
-					resolved += '.js';
-				}
-
-				if ( resolved === resolve( 'src/index.js' ) ) {
-					return FAKE_ACORN_DIST;
-				}
-			}
-		},
-		buble()
-	],
-	external: [ FAKE_ACORN_DIST ],
+	external: [ 'acorn' ],
+	paths: {
+		acorn: './acorn.js'
+	},
 	globals: {
-		'./acorn.js': 'acorn'
+		acorn: 'acorn'
 	},
 	targets: [
 		{ dest: 'dist/acorn_loose.js', format: 'umd' },
-		{ dest: 'dist/acorn_loose.es.js', format: 'es6' }
+		{ dest: 'dist/acorn_loose.es.js', format: 'es' }
 	]
 };

--- a/rollup/config.main.js
+++ b/rollup/config.main.js
@@ -6,6 +6,6 @@ export default {
 	plugins: [ buble() ],
 	targets: [
 		{ dest: 'dist/acorn.js', format: 'umd' },
-		{ dest: 'dist/acorn.es.js', format: 'es6' }
+		{ dest: 'dist/acorn.es.js', format: 'es' }
 	]
 };

--- a/rollup/config.walk.js
+++ b/rollup/config.walk.js
@@ -6,6 +6,6 @@ export default {
 	plugins: [ buble() ],
 	targets: [
 		{ dest: 'dist/walk.js', format: 'umd' },
-		{ dest: 'dist/walk.es.js', format: 'es6' }
+		{ dest: 'dist/walk.es.js', format: 'es' }
 	]
 };

--- a/src/bin/acorn.js
+++ b/src/bin/acorn.js
@@ -1,6 +1,6 @@
 import {basename} from "path"
 import {readFileSync as readFile} from "fs"
-import * as acorn from "../dist/acorn.js"
+import * as acorn from "acorn"
 
 let infile, forceFile, silent = false, compact = false, tokenize = false
 const options = {}

--- a/src/loose/expression.js
+++ b/src/loose/expression.js
@@ -1,6 +1,6 @@
 import {LooseParser} from "./state"
 import {isDummy} from "./parseutil"
-import {tokTypes as tt} from ".."
+import {tokTypes as tt} from "acorn"
 
 const lp = LooseParser.prototype
 

--- a/src/loose/index.js
+++ b/src/loose/index.js
@@ -29,7 +29,7 @@
 // invasive changes and simplifications without creating a complicated
 // tangle.
 
-import acorn from ".."
+import acorn from "acorn"
 import {LooseParser, pluginsLoose} from "./state"
 import "./tokenize"
 import "./statement"

--- a/src/loose/state.js
+++ b/src/loose/state.js
@@ -1,4 +1,4 @@
-import {tokenizer, SourceLocation, tokTypes as tt, Node, lineBreak, isNewLine} from ".."
+import {tokenizer, SourceLocation, tokTypes as tt, Node, lineBreak, isNewLine} from "acorn"
 
 // Registered plugins
 export const pluginsLoose = {}

--- a/src/loose/statement.js
+++ b/src/loose/statement.js
@@ -1,6 +1,6 @@
 import {LooseParser} from "./state"
 import {isDummy} from "./parseutil"
-import {getLineInfo, tokTypes as tt} from ".."
+import {getLineInfo, tokTypes as tt} from "acorn"
 
 const lp = LooseParser.prototype
 

--- a/src/loose/tokenize.js
+++ b/src/loose/tokenize.js
@@ -1,4 +1,4 @@
-import {tokTypes as tt, Token, isNewLine, SourceLocation, getLineInfo, lineBreakG} from ".."
+import {tokTypes as tt, Token, isNewLine, SourceLocation, getLineInfo, lineBreakG} from "acorn"
 import {LooseParser} from "./state"
 
 const lp = LooseParser.prototype


### PR DESCRIPTION
Follow-up to https://github.com/ternjs/acorn/pull/425#issuecomment-228768566 – I added a `paths` option to Rollup which means kludges like `FAKE_ACORN_DIST` are no longer necessary in the build config. Functionally nothing has changed, it's just a bit neater