### PR TITLE
Improve robustness when continuing parsing after recoverable errors.

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -513,9 +513,10 @@ pp.parsePropertyValue = function(prop, isPattern, isGenerator, startPos, startLo
         this.raiseRecoverable(start, "getter should have no params")
       else
         this.raiseRecoverable(start, "setter should have exactly one param")
+    } else {
+      if (prop.kind === "set" && prop.value.params[0].type === "RestElement")
+        this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params")
     }
-    if (prop.kind === "set" && prop.value.params[0].type === "RestElement")
-      this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params")
   } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
     if (this.keywords.test(prop.key.name) ||
         (this.strict ? this.reservedWordsStrictBind : this.reservedWords).test(prop.key.name) ||

--- a/src/statement.js
+++ b/src/statement.js
@@ -494,9 +494,10 @@ pp.parseClass = function(node, isStatement) {
           this.raiseRecoverable(start, "getter should have no params")
         else
           this.raiseRecoverable(start, "setter should have exactly one param")
+      } else {
+        if (method.kind === "set" && method.value.params[0].type === "RestElement")
+          this.raise(method.value.params[0].start, "Setter cannot use rest params")
       }
-      if (method.kind === "set" && method.value.params[0].type === "RestElement")
-        this.raise(method.value.params[0].start, "Setter cannot use rest params")
     }
   }
   node.body = this.finishNode(classBody, "ClassBody")


### PR DESCRIPTION
Setter properties or methods without parameters cause a recoverable error, hence subsequent code has to be made robust against plugins that override `raiseRecoverable` to continue parsing.