### PR TITLE
Make error for setter (class) methods with rest parameter recoverable.

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -495,7 +495,7 @@ pp.parseClass = function(node, isStatement) {
           this.raiseRecoverable(start, "setter should have exactly one param")
       } else {
         if (method.kind === "set" && method.value.params[0].type === "RestElement")
-          this.raise(method.value.params[0].start, "Setter cannot use rest params")
+          this.raiseRecoverable(method.value.params[0].start, "Setter cannot use rest params")
       }
     }
   }


### PR DESCRIPTION
This is consistent with how setter object methods are treated.