### PR TITLE
Correctly initialise reserved words for ES2017.

### DIFF
--- a/src/identifier.js
+++ b/src/identifier.js
@@ -5,6 +5,7 @@ export const reservedWords = {
   5: "class enum extends super const export import",
   6: "enum",
   7: "enum",
+  8: "enum",
   strict: "implements interface let package private protected public static yield",
   strictBind: "eval arguments"
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -29167,3 +29167,5 @@ test("0123. in/foo/i", {
     }
   ]
 })
+
+test("undefined", {}, { ecmaVersion: 8 });


### PR DESCRIPTION
This was previously left uninitialised; consequently, the `reservedWords` regular expression was set to `/^(undefined)$/`, which in turn caused `undefined` to be flagged as a reserved word.