### PR TITLE
Implement Appendix B.3.4 of ES2016 spec

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -221,8 +221,9 @@ pp.parseFunctionStatement = function(node, isAsync) {
 pp.parseIfStatement = function(node) {
   this.next()
   node.test = this.parseParenExpression()
-  node.consequent = this.parseStatement(false)
-  node.alternate = this.eat(tt._else) ? this.parseStatement(false) : null
+  // allow function declarations in branches, but only in non-strict mode
+  node.consequent = this.parseStatement(!this.strict && (this.type === tt._function))
+  node.alternate = this.eat(tt._else) ? this.parseStatement(!this.strict && (this.type === tt._function)) : null
   return this.finishNode(node, "IfStatement")
 }
 

--- a/src/statement.js
+++ b/src/statement.js
@@ -87,7 +87,7 @@ pp.parseStatement = function(declaration, topLevel, exports) {
   case tt._do: return this.parseDoStatement(node)
   case tt._for: return this.parseForStatement(node)
   case tt._function:
-    if (!declaration && this.options.ecmaVersion >= 6) break
+    if (!declaration && this.options.ecmaVersion >= 6) this.unexpected()
     return this.parseFunctionStatement(node, false)
   case tt._class:
     if (!declaration) this.unexpected()
@@ -114,22 +114,23 @@ pp.parseStatement = function(declaration, topLevel, exports) {
         this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'")
     }
     return starttype === tt._import ? this.parseImport(node) : this.parseExport(node, exports)
-  }
 
-  if (this.isAsyncFunction() && declaration) {
-    this.next()
-    return this.parseFunctionStatement(node, true)
-  }
+    // If the statement does not start with a statement keyword or a
+    // brace, it's an ExpressionStatement or LabeledStatement. We
+    // simply start parsing an expression, and afterwards, if the
+    // next token is a colon and the expression was a simple
+    // Identifier node, we switch to interpreting it as a label.
+  default:
+    if (this.isAsyncFunction() && declaration) {
+      this.next()
+      return this.parseFunctionStatement(node, true)
+    }
 
-  // If the statement does not start with a statement keyword or a
-  // brace, it's an ExpressionStatement or LabeledStatement. We
-  // simply start parsing an expression, and afterwards, if the
-  // next token is a colon and the expression was a simple
-  // Identifier node, we switch to interpreting it as a label.
-  let maybeName = this.value, expr = this.parseExpression()
-  if (starttype === tt.name && expr.type === "Identifier" && this.eat(tt.colon))
-    return this.parseLabeledStatement(node, maybeName, expr)
-  else return this.parseExpressionStatement(node, expr)
+    let maybeName = this.value, expr = this.parseExpression()
+    if (starttype === tt.name && expr.type === "Identifier" && this.eat(tt.colon))
+      return this.parseLabeledStatement(node, maybeName, expr)
+    else return this.parseExpressionStatement(node, expr)
+  }
 }
 
 pp.parseBreakContinueStatement = function(node, keyword) {

--- a/src/statement.js
+++ b/src/statement.js
@@ -218,12 +218,16 @@ pp.parseFunctionStatement = function(node, isAsync) {
   return this.parseFunction(node, true, false, isAsync)
 }
 
+pp.isFunction = function() {
+  return this.type === tt._function || this.isAsyncFunction()
+}
+
 pp.parseIfStatement = function(node) {
   this.next()
   node.test = this.parseParenExpression()
   // allow function declarations in branches, but only in non-strict mode
-  node.consequent = this.parseStatement(!this.strict && (this.type === tt._function))
-  node.alternate = this.eat(tt._else) ? this.parseStatement(!this.strict && (this.type === tt._function)) : null
+  node.consequent = this.parseStatement(!this.strict && this.isFunction())
+  node.alternate = this.eat(tt._else) ? this.parseStatement(!this.strict && this.isFunction()) : null
   return this.finishNode(node, "IfStatement")
 }
 

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3090,3 +3090,19 @@ test("({ async: true })", {
       }
   }]
 }, {ecmaVersion: 8});
+
+// Tests for B.3.4 FunctionDeclarations in IfStatement Statement Clauses
+test(
+  "if (x) async function f() {}",
+  {
+    type: "Program",
+    body: [{
+      type: "IfStatement",
+      consequent: {
+        type: "FunctionDeclaration"
+      },
+      alternate: null
+    }]
+  },
+  {ecmaVersion: 8}
+)

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -349,3 +349,42 @@ testFail("(a=2) => { 'use strict'; }", "Illegal 'use strict' directive in functi
 testFail("function foo({a}) { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:20)", { ecmaVersion: 7 })
 testFail("({a}) => { 'use strict'; }", "Illegal 'use strict' directive in function with non-simple parameter list (1:11)", { ecmaVersion: 7 })
 test("function foo(a) { 'use strict'; }", {}, { ecmaVersion: 7 });
+
+// Tests for B.3.4 FunctionDeclarations in IfStatement Statement Clauses
+test(
+  "if (x) function f() {}",
+  {
+    type: "Program",
+    body: [{
+      type: "IfStatement",
+      consequent: {
+        type: "FunctionDeclaration"
+      },
+      alternate: null
+    }]
+  },
+  { ecmaVersion: 7 }
+)
+
+test(
+  "if (x) function f() { return 23; } else function f() { return 42; }",
+  {
+    type: "Program",
+    body: [{
+      type: "IfStatement",
+      consequent: {
+        type: "FunctionDeclaration"
+      },
+      alternate: {
+        type: "FunctionDeclaration"
+      }
+    }]
+  },
+  { ecmaVersion: 7 }
+)
+
+testFail(
+  "'use strict'; if(x) function f() {}",
+  "Unexpected token (1:20)",
+  { ecmaVersion: 7 }
+)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -14234,6 +14234,7 @@ testFail("var 𫠞_ = 12;", "Unexpected character '𫠞' (1:4)", {ecmaVersion: 6
 testFail("var 𫠝_ = 10;", "Unexpected character '𫠝' (1:4)", {ecmaVersion: 5});
 testFail("if (1) let x = 10;", "Unexpected token (1:7)", {ecmaVersion: 6});
 testFail("for (;;) const x = 10;", "Unexpected token (1:9)", {ecmaVersion: 6});
+testFail("while (1) function foo(){}", "Unexpected token (1:10)", {ecmaVersion: 6});
 testFail("if (1) ; else class Cls {}", "Unexpected token (1:14)", {ecmaVersion: 6});
 
 testFail("'use strict'; [...eval] = arr", "Assigning to eval in strict mode (1:18)", {ecmaVersion: 6});
@@ -14483,8 +14484,6 @@ test("(([,]) => 0)", {
     }
   }]
 }, {ecmaVersion: 6});
-
-test("if (1) function foo() {}", {})
 
 // 'eval' and 'arguments' are not reserved word, but those can not be a BindingIdentifier.
 


### PR DESCRIPTION
This PR proposes an alternative fix for https://github.com/ternjs/acorn/issues/447: instead of falling back to parsing functions in unexpected positions as function expressions (https://github.com/ternjs/acorn/commit/19801c693fb8c32637b029626c20c9161f4179bb), we implement Appendix B.3.4 of the ES2016 spec instead, which allows function declarations to appear in `if` statement branches, though only in non-strict mode.

Unlike with https://github.com/ternjs/acorn/commit/19801c693fb8c32637b029626c20c9161f4179bb, functions in loop bodies are illegal, which is consistent with the behaviour I'm seeing on Chrome 52 and Firefox 48. (Though Node.js 5.12.0 apparently does allow function declarations in loop bodies.)