### PR TITLE
Throw "unexpected token" error when exporting a non-declaration

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -599,8 +599,10 @@ pp.parseExport = function(node, exports) {
     node.declaration = this.parseStatement(true)
     if (node.declaration.type === "VariableDeclaration")
       this.checkVariableExport(exports, node.declaration.declarations)
-    else
+    else if (node.declaration.id)
       this.checkExport(exports, node.declaration.id.name, node.declaration.id.start)
+    else
+      this.unexpected(node.declaration.start);
     node.specifiers = []
     node.source = null
   } else { // export { x, y as z } [from '...']

--- a/src/statement.js
+++ b/src/statement.js
@@ -599,10 +599,8 @@ pp.parseExport = function(node, exports) {
     node.declaration = this.parseStatement(true)
     if (node.declaration.type === "VariableDeclaration")
       this.checkVariableExport(exports, node.declaration.declarations)
-    else if (node.declaration.id)
-      this.checkExport(exports, node.declaration.id.name, node.declaration.id.start)
     else
-      this.unexpected(node.declaration.start);
+      this.checkExport(exports, node.declaration.id.name, node.declaration.id.start)
     node.specifiers = []
     node.source = null
   } else { // export { x, y as z } [from '...']
@@ -657,7 +655,12 @@ pp.checkVariableExport = function(exports, decls) {
 }
 
 pp.shouldParseExportStatement = function() {
-  return this.type.keyword || this.isLet() || this.isAsyncFunction()
+  return this.type.keyword === "var"
+    || this.type.keyword === "const"
+    || this.type.keyword === "class"
+    || this.type.keyword === "function"
+    || this.isLet()
+    || this.isAsyncFunction()
 }
 
 // Parses a comma-separated list of module exports.

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -4116,6 +4116,9 @@ test("export class Class {}", {
   locations: true
 });
 
+testFail("export new Foo();", "Unexpected token (1:7)", {ecmaVersion: 6, sourceType: "module"});
+testFail("export typeof foo;", "Unexpected token (1:7)", {ecmaVersion: 6, sourceType: "module"});
+
 test("export default 42", {
   type: "Program",
   body: [{


### PR DESCRIPTION
Currently, the following (correctly) errors:
```js
export typeof foo;
export new Foo();
````
with the error `TypeError: Cannot read property 'name' of undefined`.

This error message occurs because that path [assumes the presence of an `id` property on the given node](https://github.com/ternjs/acorn/blob/master/src/statement.js#L603). This is not always true because the node [may be any keyword token at the beginning of the expression being evaluated](https://github.com/ternjs/acorn/blob/master/src/statement.js#L658).

This change adds a guard for the presence of the `id` property and, instead of crashing, throws a more helpful `unexpected token` error with the location of the invalid keyword.