### PR TITLE
Disallow non-configurable globals from being redeclared

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -16,6 +16,17 @@ const assign = Object.assign || function(target, ...sources) {
   return target
 }
 
+pp.initScopeStack = function() {
+  this.scopeStack = []
+  this.enterFunctionScope()
+  if (this.options.sourceType === "module" || !this.options.allowReturnOutsideFunction) {
+    // Disallow non-configurable properties of the global object from being shadowed at the top level
+    this.declareVarName("Infinity")
+    this.declareVarName("NaN")
+    this.declareVarName("undefined")
+  }
+}
+
 // The functions in this module keep track of declared variables in the current scope in order to detect duplicate variable names.
 
 pp.enterFunctionScope = function() {

--- a/src/state.js
+++ b/src/state.js
@@ -87,8 +87,7 @@ export class Parser {
       this.skipLineComment(2)
 
     // Scope tracking for duplicate variable names (see scope.js)
-    this.scopeStack = []
-    this.enterFunctionScope()
+    this.initScopeStack()
   }
 
   // DEPRECATED Kept for backwards compatibility until 3.0 in case a plugin uses them

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15673,3 +15673,19 @@ test("() => {}\n/re/", {}, {ecmaVersion: 6})
 test("(() => {}) + 2", {}, {ecmaVersion: 6})
 
 testFail("(x) => {} + 2", "Unexpected token (1:10)", {ecmaVersion: 6})
+
+testFail("let undefined", "Identifier 'undefined' has already been declared (1:4)", {ecmaVersion: 6})
+
+testFail("let Infinity", "Identifier 'Infinity' has already been declared (1:4)", {ecmaVersion: 6})
+
+testFail("let NaN", "Identifier 'NaN' has already been declared (1:4)", {ecmaVersion: 6})
+
+testFail(
+  "let undefined",
+  "Identifier 'undefined' has already been declared (1:4)",
+  {ecmaVersion: 6, allowReturnOutsideFunction: true, sourceType: 'module'}
+)
+
+test("var undefined", {}, {ecmaVersion: 6})
+
+test("let undefined", {}, {ecmaVersion: 6, allowReturnOutsideFunction: true})


### PR DESCRIPTION
Based on the spec ([1](https://tc39.github.io/ecma262/#sec-hasrestrictedglobalproperty), [2](https://tc39.github.io/ecma262/#sec-globaldeclarationinstantiation)), it's an early error to redeclare non-configurable globals with lexical variables at the top level of a program. This is determined by calling `[[GetOwnProperty]]` on the global object at parse time.

The spec mandates three non-configurable globals: `undefined`, `Infinity`, and `NaN`. As a result, `let undefined;` at the top level is always a syntax error for any compliant engine. This commit updates acorn to report these redeclarations as syntax errors.

Some environments create additional non-configurable globals (e.g. `window` in browsers), and the global object can also be modified at runtime, so it's not possible to statically detect all syntax errors for a script if it's parsed after other code has been run.