### PR TITLE
Make the keywords regexp a non-capturing one.

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -7,7 +7,7 @@ import {getOptions} from "./options"
 export const plugins = {}
 
 function keywordRegexp(words) {
-  return new RegExp("^(" + words.replace(/ /g, "|") + ")$")
+  return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$")
 }
 
 export class Parser {


### PR DESCRIPTION
I noticed the regexp wasn't using it's capture group so I made it non-capturing.