### PR TITLE
Fix syntax error for named functions in strict mode (fixes #534)

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -729,7 +729,7 @@ pp.parseFunctionBody = function(node, isArrowFunction) {
 
   if (this.strict && node.id) {
     // Ensure the function name isn't a forbidden identifier in strict mode, e.g. 'eval'
-    this.checkLVal(node.id, "var")
+    this.checkLVal(node.id, "none")
   }
   this.strict = oldStrict
 }

--- a/src/lval.js
+++ b/src/lval.js
@@ -172,6 +172,10 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
 
 // Verify that a node is an lval — something that can be assigned
 // to.
+// bindingType can be either:
+// 'var' indicating that the lval creates a 'var' binding
+// 'let' indicating that the lval creates a lexical ('let' or 'const') binding
+// 'none' indicating that the binding should be checked for illegal identifiers, but not for duplicate references
 
 pp.checkLVal = function(expr, bindingType, checkClashes) {
   switch (expr.type) {
@@ -183,7 +187,7 @@ pp.checkLVal = function(expr, bindingType, checkClashes) {
         this.raiseRecoverable(expr.start, "Argument name clash")
       checkClashes[expr.name] = true
     }
-    if (bindingType) {
+    if (bindingType && bindingType !== "none") {
       if (
         bindingType === "var" && !this.canDeclareVarName(expr.name) ||
         bindingType !== "var" && !this.canDeclareLexicalName(expr.name)

--- a/test/tests.js
+++ b/test/tests.js
@@ -29199,3 +29199,5 @@ test("try {} catch (foo) {} let foo;", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { { let foo; } }", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { function x() { var foo; } }", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { function x(foo) {} }", {}, {ecmaVersion: 6})
+
+test("'use strict'; let foo = function foo() {}", {}, {ecmaVersion: 6})


### PR DESCRIPTION
This fixes an error where assigning to a named function with `let` or `const` in strict mode could cause a "duplicate variable name" error. Fixes #534

(Originally reported at https://github.com/eslint/eslint/issues/8378)