### PR TITLE
Implement template literal revision

### DIFF
--- a/src/loose/expression.js
+++ b/src/loose/expression.js
@@ -318,9 +318,18 @@ lp.parseNew = function() {
 
 lp.parseTemplateElement = function() {
   let elem = this.startNode()
-  elem.value = {
-    raw: this.input.slice(this.tok.start, this.tok.end).replace(/\r\n?/g, "\n"),
-    cooked: this.tok.value
+
+  // The loose parser accepts invalid unicode escapes even in untagged templates.
+  if (this.tok.type === tt.invalidTemplate) {
+    elem.value = {
+      raw: this.tok.value,
+      cooked: null
+    }
+  } else {
+    elem.value = {
+      raw: this.input.slice(this.tok.start, this.tok.end).replace(/\r\n?/g, "\n"),
+      cooked: this.tok.value
+    }
   }
   this.next()
   elem.tail = this.tok.type === tt.backQuote

--- a/src/tokencontext.js
+++ b/src/tokencontext.js
@@ -22,7 +22,7 @@ export const types = {
   b_tmpl: new TokContext("${", true),
   p_stat: new TokContext("(", false),
   p_expr: new TokContext("(", true),
-  q_tmpl: new TokContext("`", true, true, p => p.readTmplToken()),
+  q_tmpl: new TokContext("`", true, true, p => p.tryReadTemplateToken()),
   f_expr: new TokContext("function", true),
   f_expr_gen: new TokContext("function", true, false, null, true),
   f_gen: new TokContext("function", false, false, null, true)

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -424,7 +424,7 @@ pp.readRegexp = function() {
         // be replaced by `[x-b]` which throws an error.
         tmp = tmp.replace(/\\u\{([0-9a-fA-F]+)\}/g, (_match, code, offset) => {
           code = Number("0x" + code)
-          if (code > 0x10FFFF) this.raise(start + offset + 3, "Code point out of bounds")
+          if (code > 0x10FFFF) this.invalidStringToken(start + offset + 3, "Code point out of bounds")
           return "x"
         })
         tmp = tmp.replace(/\\u([a-fA-F0-9]{4})|[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x")
@@ -508,12 +508,12 @@ pp.readNumber = function(startsWithDot) {
 pp.readCodePoint = function() {
   let ch = this.input.charCodeAt(this.pos), code
 
-  if (ch === 123) {
+  if (ch === 123) { // '{'
     if (this.options.ecmaVersion < 6) this.unexpected()
     let codePos = ++this.pos
     code = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos)
     ++this.pos
-    if (code > 0x10FFFF) this.raise(codePos, "Code point out of bounds")
+    if (code > 0x10FFFF) this.invalidStringToken(codePos, "Code point out of bounds")
   } else {
     code = this.readHexChar(4)
   }
@@ -548,13 +548,38 @@ pp.readString = function(quote) {
 
 // Reads template string tokens.
 
+const INVALID_TEMPLATE_ESCAPE_ERROR = {}
+
+pp.tryReadTemplateToken = function() {
+  this.inTemplateElement = true
+  try {
+    this.readTmplToken()
+  } catch (err) {
+    if (err === INVALID_TEMPLATE_ESCAPE_ERROR) {
+      this.readInvalidTemplateToken()
+    } else {
+      throw err
+    }
+  }
+
+  this.inTemplateElement = false
+}
+
+pp.invalidStringToken = function(position, message) {
+  if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+    throw INVALID_TEMPLATE_ESCAPE_ERROR
+  } else {
+    this.raise(position, message)
+  }
+}
+
 pp.readTmplToken = function() {
   let out = "", chunkStart = this.pos
   for (;;) {
     if (this.pos >= this.input.length) this.raise(this.start, "Unterminated template")
     let ch = this.input.charCodeAt(this.pos)
     if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) { // '`', '${'
-      if (this.pos === this.start && this.type === tt.template) {
+      if (this.pos === this.start && (this.type === tt.template || this.type === tt.invalidTemplate)) {
         if (ch === 36) {
           this.pos += 2
           return this.finishToken(tt.dollarBraceL)
@@ -594,6 +619,29 @@ pp.readTmplToken = function() {
   }
 }
 
+// Reads a template token to search for the end, without validating any escape sequences
+pp.readInvalidTemplateToken = function() {
+  for (; this.pos < this.input.length; this.pos++) {
+    switch (this.input[this.pos]) {
+    case "\\":
+      ++this.pos
+      break
+
+    case "$":
+      if (this.input[this.pos + 1] !== "{") {
+        break
+      }
+    // falls through
+
+    case "`":
+      return this.finishToken(tt.invalidTemplate, this.input.slice(this.start, this.pos))
+
+    // no default
+    }
+  }
+  this.raise(this.start, "Unterminated template")
+}
+
 // Used to read escaped characters
 
 pp.readEscapedChar = function(inTemplate) {
@@ -621,7 +669,7 @@ pp.readEscapedChar = function(inTemplate) {
         octal = parseInt(octalStr, 8)
       }
       if (octalStr !== "0" && (this.strict || inTemplate)) {
-        this.raise(this.pos - 2, "Octal literal in strict mode")
+        this.invalidStringToken(this.pos - 2, "Octal literal in strict mode")
       }
       this.pos += octalStr.length - 1
       return String.fromCharCode(octal)
@@ -635,7 +683,7 @@ pp.readEscapedChar = function(inTemplate) {
 pp.readHexChar = function(len) {
   let codePos = this.pos
   let n = this.readInt(16, len)
-  if (n === null) this.raise(codePos, "Bad character escape sequence")
+  if (n === null) this.invalidStringToken(codePos, "Bad character escape sequence")
   return n
 }
 
@@ -658,11 +706,11 @@ pp.readWord1 = function() {
       word += this.input.slice(chunkStart, this.pos)
       let escStart = this.pos
       if (this.input.charCodeAt(++this.pos) != 117) // "u"
-        this.raise(this.pos, "Expecting Unicode escape sequence \\uXXXX")
+        this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX")
       ++this.pos
       let esc = this.readCodePoint()
       if (!(first ? isIdentifierStart : isIdentifierChar)(esc, astral))
-        this.raise(escStart, "Invalid Unicode escape")
+        this.invalidStringToken(escStart, "Invalid Unicode escape")
       word += codePointToString(esc)
       chunkStart = this.pos
     } else {

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -424,7 +424,7 @@ pp.readRegexp = function() {
         // be replaced by `[x-b]` which throws an error.
         tmp = tmp.replace(/\\u\{([0-9a-fA-F]+)\}/g, (_match, code, offset) => {
           code = Number("0x" + code)
-          if (code > 0x10FFFF) this.invalidStringToken(start + offset + 3, "Code point out of bounds")
+          if (code > 0x10FFFF) this.raise(start + offset + 3, "Code point out of bounds")
           return "x"
         })
         tmp = tmp.replace(/\\u([a-fA-F0-9]{4})|[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x")

--- a/src/tokentype.js
+++ b/src/tokentype.js
@@ -72,6 +72,7 @@ export const types = {
   question: new TokenType("?", beforeExpr),
   arrow: new TokenType("=>", beforeExpr),
   template: new TokenType("template"),
+  invalidTemplate: new TokenType("invalidTemplate"),
   ellipsis: new TokenType("...", beforeExpr),
   backQuote: new TokenType("`", startsExpr),
   dollarBraceL: new TokenType("${", {beforeExpr: true, startsExpr: true}),

--- a/test/run.js
+++ b/test/run.js
@@ -8,6 +8,7 @@
     require("./tests-es7.js");
     require("./tests-asyncawait.js");
     require("./tests-trailing-commas-in-func.js");
+    require("./tests-template-literal-revision.js");
     acorn = require("../dist/acorn")
     require("../dist/acorn_loose")
   } else {

--- a/test/tests-template-literal-revision.js
+++ b/test/tests-template-literal-revision.js
@@ -1,0 +1,551 @@
+if (typeof exports != "undefined") {
+  var test = require("./driver.js").test
+  var testFail = require("./driver.js").testFail
+}
+
+test("`foo`", {
+  type: "Program",
+  start: 0,
+  end: 5,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 5,
+      expression: {
+        type: "TemplateLiteral",
+        start: 0,
+        end: 5,
+        expressions: [],
+        quasis: [
+          {
+            type: "TemplateElement",
+            start: 1,
+            end: 4,
+            value: {
+              raw: "foo",
+              cooked: "foo"
+            },
+            tail: true
+          }
+        ]
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("`foo\\u25a0`", {
+  type: "Program",
+  start: 0,
+  end: 11,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 11,
+      expression: {
+        type: "TemplateLiteral",
+        start: 0,
+        end: 11,
+        expressions: [],
+        quasis: [
+          {
+            type: "TemplateElement",
+            start: 1,
+            end: 10,
+            value: {
+              raw: "foo\\u25a0",
+              cooked: "foo■"
+            },
+            tail: true
+          }
+        ]
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("`foo${bar}\\u25a0`", {
+  type: "Program",
+  start: 0,
+  end: 17,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 17,
+      expression: {
+        type: "TemplateLiteral",
+        start: 0,
+        end: 17,
+        expressions: [
+          {
+            type: "Identifier",
+            start: 6,
+            end: 9,
+            name: "bar"
+          }
+        ],
+        quasis: [
+          {
+            type: "TemplateElement",
+            start: 1,
+            end: 4,
+            value: {
+              raw: "foo",
+              cooked: "foo"
+            },
+            tail: false
+          },
+          {
+            type: "TemplateElement",
+            start: 10,
+            end: 16,
+            value: {
+              raw: "\\u25a0",
+              cooked: "■"
+            },
+            tail: true
+          }
+        ]
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\u25a0`", {
+  type: "Program",
+  start: 0,
+  end: 11,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 11,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 11,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 11,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 10,
+              value: {
+                raw: "\\u25a0",
+                cooked: "■"
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`foo${bar}\\u25a0`", {
+  type: "Program",
+  start: 0,
+  end: 20,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 20,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 20,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 20,
+          expressions: [
+            {
+              type: "Identifier",
+              start: 9,
+              end: 12,
+              name: "bar"
+            }
+          ],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 7,
+              value: {
+                raw: "foo",
+                cooked: "foo"
+              },
+              tail: false
+            },
+            {
+              type: "TemplateElement",
+              start: 13,
+              end: 19,
+              value: {
+                raw: "\\u25a0",
+                cooked: "■"
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+testFail("`\\unicode`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+testFail("`\\u`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+testFail("`\\u{`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+testFail("`\\u{abcdx`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+testFail("`\\u{abcdx}`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+testFail("`\\xylophone`", "Bad escape sequence in untagged template literal (1:1)", {ecmaVersion: 9})
+
+testFail("foo`\\unicode`", "Bad character escape sequence (1:6)", {ecmaVersion: 8})
+testFail("foo`\\xylophone`", "Bad character escape sequence (1:6)", {ecmaVersion: 8})
+
+testFail("foo`\\unicode", "Unterminated template (1:4)", {ecmaVersion: 9})
+testFail("foo`\\unicode\\`", "Unterminated template (1:4)", {ecmaVersion: 9})
+
+test("foo`\\unicode`", {
+  type: "Program",
+  start: 0,
+  end: 13,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 13,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 13,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 13,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 12,
+              value: {
+                raw: "\\unicode",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`foo${bar}\\unicode`", {
+  type: "Program",
+  start: 0,
+  end: 22,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 22,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 22,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 22,
+          expressions: [
+            {
+              type: "Identifier",
+              start: 9,
+              end: 12,
+              name: "bar"
+            }
+          ],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 7,
+              value: {
+                raw: "foo",
+                cooked: "foo"
+              },
+              tail: false
+            },
+            {
+              type: "TemplateElement",
+              start: 13,
+              end: 21,
+              value: {
+                raw: "\\unicode",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\u`", {
+  type: "Program",
+  start: 0,
+  end: 7,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 7,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 7,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 7,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 6,
+              value: {
+                raw: "\\u",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\u{`", {
+  type: "Program",
+  start: 0,
+  end: 8,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 8,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 8,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 8,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 7,
+              value: {
+                raw: "\\u{",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\u{abcdx`", {
+  type: "Program",
+  start: 0,
+  end: 13,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 13,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 13,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 13,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 12,
+              value: {
+                raw: "\\u{abcdx",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\u{abcdx}`", {
+  type: "Program",
+  start: 0,
+  end: 14,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 14,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 14,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 14,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 13,
+              value: {
+                raw: "\\u{abcdx}",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})
+
+test("foo`\\unicode\\\\`", {
+  type: "Program",
+  start: 0,
+  end: 15,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 15,
+      expression: {
+        type: "TaggedTemplateExpression",
+        start: 0,
+        end: 15,
+        tag: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo"
+        },
+        quasi: {
+          type: "TemplateLiteral",
+          start: 3,
+          end: 15,
+          expressions: [],
+          quasis: [
+            {
+              type: "TemplateElement",
+              start: 4,
+              end: 14,
+              value: {
+                raw: "\\unicode\\\\",
+                cooked: null
+              },
+              tail: true
+            }
+          ]
+        }
+      }
+    }
+  ],
+  sourceType: "script"
+}, {ecmaVersion: 9})


### PR DESCRIPTION
The [template literal revision proposal](https://github.com/tc39/proposal-template-literal-revision) reached stage 4 in the March 2017 TC39 meeting. This commit adds support for it when `ecmaVersion` is at least 9.

The template literal revision allows invalid escape sequences in tagged template literals, to make it easier to write embedded languages and DSLs. In [ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/experimental/invalid-tagged-template-escapes.md), this is represented as a `TemplateElement` node with a null `cooked` value.

To allow bad unicode escapes to be tokenized, this updates the template tokenizer to fall back to tokenizing an `invalidTemplate` token if it encounters an invalid escape, rather than immediately throwing an error.