### PR TITLE
Remove /src directory from npm package by including it in .npmignore file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@
 .gitattributes
 .tern-project
 .travis.yml
+/src


### PR DESCRIPTION
Hello!
In previous pull request related to .npmignore was 'src' dir left out intentionaly https://github.com/ternjs/acorn/pull/483 (see comment) but without explanation why. 
This PR proposes remove it from npm package

The "src" directory is not needed as all javascript files ready for production use are compiled into "dist" and "bin" directory accordingly.
This reduces size of installed package without change on functionality for around ~220KB
Alternatively if there is reason to keep `src` in package someone can put reasons here in comment so the explanation will be preserved for future generations :)
thank you!
