### PR TITLE
Parse octal numbers with 8 or 9 as decimal if non-strict

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -498,7 +498,8 @@ pp.readNumber = function(startsWithDot) {
   let str = this.input.slice(start, this.pos), val
   if (isFloat) val = parseFloat(str)
   else if (!octal || str.length === 1) val = parseInt(str, 10)
-  else if (/[89]/.test(str) || this.strict) this.raise(start, "Invalid number")
+  else if (this.strict) this.raise(start, "Invalid number")
+  else if (/[89]/.test(str)) val = parseInt(str, 10)
   else val = parseInt(str, 8)
   return this.finishToken(tt.num, val)
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -26945,11 +26945,11 @@ testFail("3x0",
 testFail("0x",
          "Expected number in radix 16 (1:2)");
 
-testFail("09",
-         "Invalid number (1:0)");
+testFail("'use strict'; 09",
+         "Invalid number (1:14)");
 
-testFail("018",
-         "Invalid number (1:0)");
+testFail("'use strict'; 018",
+         "Invalid number (1:14)");
 
 testFail("01a",
          "Identifier directly after number (1:2)");
@@ -29165,6 +29165,20 @@ test("0123. in/foo/i", {
           "type": "Identifier",
           "name": "i"
         }
+      }
+    }
+  ]
+})
+
+test("0128", {
+  "type": "Program",
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "Literal",
+        "value": 128,
+        "raw": "0128"
       }
     }
   ]


### PR DESCRIPTION
Numbers like `0128` do parse fine in most engines in non strict mode.

Previous discussions:
https://github.com/babel/babylon/issues/420