### PR TITLE
Sort plugins by `priority` configuration value

### DIFF
--- a/src/loose/state.js
+++ b/src/loose/state.js
@@ -152,11 +152,13 @@ export class LooseParser {
   }
 
   loadPlugins(pluginConfigs) {
-    for (let name in pluginConfigs) {
-      let plugin = pluginsLoose[name]
-      if (!plugin) throw new Error("Plugin '" + name + "' not found")
-      plugin(this, pluginConfigs[name])
-    }
+    Object.keys(pluginConfigs)
+      .sort((a, b) => b.priority - a.priority) // undefined is in the end, as with 0 priority
+      .forEach(name => {
+        let plugin = pluginsLoose[name]
+        if (!plugin) throw new Error("Plugin '" + name + "' not found")
+        plugin(this, pluginConfigs[name])
+      })
   }
 
   parse() {

--- a/src/state.js
+++ b/src/state.js
@@ -100,11 +100,13 @@ export class Parser {
   }
 
   loadPlugins(pluginConfigs) {
-    for (let name in pluginConfigs) {
-      let plugin = plugins[name]
-      if (!plugin) throw new Error("Plugin '" + name + "' not found")
-      plugin(this, pluginConfigs[name])
-    }
+    Object.keys(pluginConfigs)
+      .sort((a, b) => b.priority - a.priority) // undefined is in the end, as with 0 priority
+      .forEach(name => {
+        let plugin = plugins[name]
+        if (!plugin) throw new Error("Plugin '" + name + "' not found")
+        plugin(this, pluginConfigs[name])
+      })
   }
 
   parse() {


### PR DESCRIPTION
Hi!

It would be really nice to have an ability to sort an order of plugin execution. Since plugins option is an object and not an array, I suggest adding an optional field `priority` which will get them evaluated in descending order.

Please see the suggested code change in this PR.