### PR TITLE
Simplify let statement check

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -33,16 +33,9 @@ const loopLabel = {kind: "loop"}, switchLabel = {kind: "switch"}
 pp.isLet = function() {
   if (this.type !== tt.name || this.options.ecmaVersion < 6 || this.value != "let") return false
   skipWhiteSpace.lastIndex = this.pos
-  let skip = skipWhiteSpace.exec(this.input)
-  let next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next)
-  if (nextCh === 91 || nextCh == 123) return true // '{' and '['
-  if (isIdentifierStart(nextCh, true)) {
-    let pos = next + 1
-    while (isIdentifierChar(this.input.charCodeAt(pos), true)) ++pos
-    let ident = this.input.slice(next, pos)
-    if (!this.isKeyword(ident)) return true
-  }
-  return false
+  let skip = skipWhiteSpace.exec(this.input)[0].length
+  let nextCh = this.input.charCodeAt(this.pos + skip)
+  return nextCh === 91 /* '{' */ || nextCh == 123 /* '[' */ || isIdentifierStart(nextCh, true)
 }
 
 // check 'async [no LineTerminator here] function'

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15721,3 +15721,5 @@ test("() => {}\n/re/", {}, {ecmaVersion: 6})
 test("(() => {}) + 2", {}, {ecmaVersion: 6})
 
 testFail("(x) => {} + 2", "Unexpected token (1:10)", {ecmaVersion: 6})
+
+testFail("let default", "Unexpected token (1:4)", {ecmaVersion: 6, sourceType: "module"})


### PR DESCRIPTION
Fixes #544, but I'm somewhat suspicious as to what I'm potentially breaking by removing this code.

@marijnh do you remember why you added these extra checks in the first place?

I can't think of cases where `let` at the beginning of statement would be immediately followed by a keyword and thus would require such checks, and there are no tests covering this but would prefer the second pair of eyes.