### PR TITLE
JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ tokenizer.
 Implements an abstract syntax tree walker. Will store its interface in
 `acorn.walk` when loaded without a module system.
 
+JSX is supported providing you use the [plugin](https://github.com/RReverser/acorn-jsx).
+
 **simple**`(node, visitors, base, state)` does a 'simple' walk over
 a tree. `node` should be the AST node to walk, and `visitors` an
 object with properties whose names correspond to node types in the

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -338,3 +338,62 @@ base.MethodDefinition = base.Property = (node, st, c) => {
   if (node.computed) c(node.key, st, "Expression")
   c(node.value, st, "Expression")
 }
+
+base.JSXElement = (node, st, c) => {
+  c(node.openingElement, st)
+  if (node.closingElement) c(node.closingElement, st)
+  for (let child of node.children)
+    if (child.type === "JSXElement")
+      c(child, st, "Expression")
+    else
+      c(child, st)
+}
+base.JSXOpeningElement = (node, st, c) => {
+  if (node.name.type === "JSXIdentifier")
+    c(node.name, st)
+  else
+    c(node.name, st, "Expression")
+  for (let attribute of node.attributes)
+    c(attribute, st)
+}
+base.JSXClosingElement = (node, st, c) => {
+  if (node.name.type === "JSXIdentifier")
+    c(node.name, st)
+  else
+    c(node.name, st, "Expression")
+}
+base.JSXIdentifier = (node, st, c) => {
+  c(node, st, "Identifier")
+}
+base.JSXMemberExpression = (node, st, c) => {
+  if (node.object.type === "JSXIdentifier")
+    c(node.object, st)
+  else
+    c(node.object, st, "Expression")
+  c(node.property, st)
+}
+base.JSXNamespacedName = (node, st, c) => {
+  c(node.name, st)
+  c(node.namespace, st)
+}
+base.JSXAttribute = (node, st, c) => {
+  if (node.name.type === "JSXIdentifier")
+    c(node.name, st)
+  else
+    c(node.name, st, "Expression")
+  if (node.value)
+    if (node.value.type === "JSXExpressionContainer")
+      c(node.value, st)
+    else
+      c(node.value, st, "Expression")
+}
+base.JSXSpreadAttribute = (node, st, c) => {
+  c(node, st, "SpreadElement")
+}
+base.JSXExpressionContainer = (node, st, c) => {
+  if (node.expression.type === "JSXEmptyExpression")
+    c(node.expression, st)
+  else
+    c(node.expression, st, "Expression")
+}
+base.JSXEmptyExpression = base.JSXSpreadChild = base.JSXText = ignore


### PR DESCRIPTION
This adds support for the JSX AST tree in the walker. 

This requires JSX parsing, e.g. with acorn-jsx.