### PR TITLE
Fix syntax error of async shorthand properties

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -553,8 +553,8 @@ pp.parseObj = function(isPattern, refDestructuringErrors) {
     }
     this.parsePropertyName(prop)
     if (!isPattern && this.options.ecmaVersion >= 8 && !isGenerator && !prop.computed &&
-        prop.key.type === "Identifier" && prop.key.name === "async" && this.type !== tt.parenL &&
-        this.type !== tt.colon && this.type !== tt.comma && this.type !== tt.braceR &&
+        prop.key.type === "Identifier" && prop.key.name === "async" &&
+        (this.type === tt.name || this.type === tt.num || this.type === tt.string || this.type === tt.bracketL) &&
         !lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) {
       isAsync = true
       this.parsePropertyName(prop, refDestructuringErrors)

--- a/src/expression.js
+++ b/src/expression.js
@@ -19,6 +19,7 @@
 import {types as tt} from "./tokentype"
 import {Parser} from "./state"
 import {DestructuringErrors} from "./parseutil"
+import {lineBreak} from "./whitespace"
 
 const pp = Parser.prototype
 
@@ -553,7 +554,8 @@ pp.parseObj = function(isPattern, refDestructuringErrors) {
     this.parsePropertyName(prop)
     if (!isPattern && this.options.ecmaVersion >= 8 && !isGenerator && !prop.computed &&
         prop.key.type === "Identifier" && prop.key.name === "async" && this.type !== tt.parenL &&
-        this.type !== tt.colon && !this.canInsertSemicolon()) {
+        this.type !== tt.colon && this.type !== tt.comma && this.type !== tt.braceR &&
+        !lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) {
       isAsync = true
       this.parsePropertyName(prop, refDestructuringErrors)
     } else {

--- a/src/loose/expression.js
+++ b/src/loose/expression.js
@@ -376,8 +376,8 @@ lp.parseObj = function() {
     }
     this.parsePropertyName(prop)
     if (!prop.computed &&
-        prop.key.type === "Identifier" && prop.key.name === "async" && this.tok.type !== tt.parenL &&
-        this.tok.type !== tt.colon && this.tok.type !== tt.comma && this.tok.type !== tt.braceR &&
+        prop.key.type === "Identifier" && prop.key.name === "async" &&
+        (this.tok.type === tt.name || this.tok.type === tt.num || this.tok.type === tt.string || this.tok.type === tt.bracketL) &&
         !lineBreak.test(this.input.slice(this.last.end, this.tok.start))) {
       this.parsePropertyName(prop)
       isAsync = true

--- a/src/loose/expression.js
+++ b/src/loose/expression.js
@@ -1,6 +1,6 @@
 import {LooseParser} from "./state"
 import {isDummy} from "./parseutil"
-import {tokTypes as tt} from "../index"
+import {tokTypes as tt, lineBreak} from "../index"
 
 const lp = LooseParser.prototype
 
@@ -377,7 +377,8 @@ lp.parseObj = function() {
     this.parsePropertyName(prop)
     if (!prop.computed &&
         prop.key.type === "Identifier" && prop.key.name === "async" && this.tok.type !== tt.parenL &&
-        this.tok.type !== tt.colon && !this.canInsertSemicolon()) {
+        this.tok.type !== tt.colon && this.tok.type !== tt.comma && this.tok.type !== tt.braceR &&
+        !lineBreak.test(this.input.slice(this.last.end, this.tok.start))) {
       this.parsePropertyName(prop)
       isAsync = true
     } else {

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3223,3 +3223,297 @@ test(
   },
   {ecmaVersion: 8}
 )
+test(
+  "({async = 0} = {})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 18,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 18,
+        "expression": {
+          "type": "AssignmentExpression",
+          "start": 1,
+          "end": 17,
+          "operator": "=",
+          "left": {
+            "type": "ObjectPattern",
+            "start": 1,
+            "end": 12,
+            "properties": [
+              {
+                "type": "Property",
+                "start": 2,
+                "end": 11,
+                "method": false,
+                "shorthand": true,
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 2,
+                  "end": 7,
+                  "name": "async"
+                },
+                "kind": "init",
+                "value": {
+                  "type": "AssignmentPattern",
+                  "start": 2,
+                  "end": 11,
+                  "left": {
+                    "type": "Identifier",
+                    "start": 2,
+                    "end": 7,
+                    "name": "async"
+                  },
+                  "right": {
+                    "type": "Literal",
+                    "start": 10,
+                    "end": 11,
+                    "value": 0,
+                    "raw": "0"
+                  }
+                }
+              }
+            ]
+          },
+          "right": {
+            "type": "ObjectExpression",
+            "start": 15,
+            "end": 17,
+            "properties": []
+          }
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)
+
+// async functions with vary names.
+test(
+  "({async \"foo\"(){}})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 19,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 19,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 18,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 17,
+              "method": true,
+              "shorthand": false,
+              "computed": false,
+              "key": {
+                "type": "Literal",
+                "start": 8,
+                "end": 13,
+                "value": "foo",
+                "raw": "\"foo\""
+              },
+              "kind": "init",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 13,
+                "end": 17,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 15,
+                  "end": 17,
+                  "body": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)
+test(
+  "({async 'foo'(){}})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 19,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 19,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 18,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 17,
+              "method": true,
+              "shorthand": false,
+              "computed": false,
+              "key": {
+                "type": "Literal",
+                "start": 8,
+                "end": 13,
+                "value": "foo",
+                "raw": "'foo'"
+              },
+              "kind": "init",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 13,
+                "end": 17,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 15,
+                  "end": 17,
+                  "body": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)
+test(
+  "({async 100(){}})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 17,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 17,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 16,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 15,
+              "method": true,
+              "shorthand": false,
+              "computed": false,
+              "key": {
+                "type": "Literal",
+                "start": 8,
+                "end": 11,
+                "value": 100,
+                "raw": "100"
+              },
+              "kind": "init",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 11,
+                "end": 15,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 13,
+                  "end": 15,
+                  "body": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)
+test(
+  "({async [foo](){}})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 19,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 19,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 18,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 17,
+              "method": true,
+              "shorthand": false,
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "name": "foo"
+              },
+              "kind": "init",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 13,
+                "end": 17,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 15,
+                  "end": 17,
+                  "body": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3110,3 +3110,116 @@ test(
 testFail("(async)(a) => 12", "Unexpected token (1:11)", {ecmaVersion: 8})
 
 testFail("f = async ((x)) => x", "Parenthesized pattern (1:11)", {ecmaVersion: 8})
+
+// allow 'async' as a shorthand property in script.
+test(
+  "({async})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 9,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 9,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 8,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 7,
+              "method": false,
+              "shorthand": true,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 2,
+                "end": 7,
+                "name": "async"
+              },
+              "kind": "init",
+              "value": {
+                "type": "Identifier",
+                "start": 2,
+                "end": 7,
+                "name": "async"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)
+test(
+  "({async, foo})",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 14,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 14,
+        "expression": {
+          "type": "ObjectExpression",
+          "start": 1,
+          "end": 13,
+          "properties": [
+            {
+              "type": "Property",
+              "start": 2,
+              "end": 7,
+              "method": false,
+              "shorthand": true,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 2,
+                "end": 7,
+                "name": "async"
+              },
+              "kind": "init",
+              "value": {
+                "type": "Identifier",
+                "start": 2,
+                "end": 7,
+                "name": "async"
+              }
+            },
+            {
+              "type": "Property",
+              "start": 9,
+              "end": 12,
+              "method": false,
+              "shorthand": true,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "name": "foo"
+              },
+              "kind": "init",
+              "value": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "name": "foo"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  {ecmaVersion: 8}
+)


### PR DESCRIPTION
Acorn throws syntax errors at `async` shorthand properties if `ecmaVersion: 8` is specified. However, [`IdentifierReference`](https://tc39.github.io/ecma262/#prod-IdentifierReference) allows `async`, so `async` shorthand properties should be legal.

```js
const async = 1
const foo = {async}
const bar = {async, foo}
```

This PR fixes the syntax errors.