### PR TITLE
Update supported ecmaVersion values in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ object referring to that same position.
 [estree]: https://github.com/estree/estree
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
-  either 3, 5, 6 (2015), 7 (2016), or 8 (2017). This influences support for strict
+  either 3, 5, 6 (2015), 7 (2016), 8 (2017), or 9 (2018). This influences support for strict
   mode, the set of reserved words, and support for new syntax features.
   Default is 7.
 


### PR DESCRIPTION
As of https://github.com/ternjs/acorn/commit/f1a88fe75c19598e716c608a953db294fa9701e1, `ecmaVersion: 9` is now supported.