### PR TITLE
fix parsing errors about template literals (fixes #575)

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -814,6 +814,13 @@ pp.parseIdent = function(liberal, isBinding) {
     node.name = this.value
   } else if (this.type.keyword) {
     node.name = this.type.keyword
+
+    // To fix https://github.com/ternjs/acorn/issues/575
+    // `class` and `function` keywords push new context into this.context.
+    // But there is no chance to pop the context if the keyword is consumed as an identifier such as a property name.
+    if (node.name === "class" || node.name === "function") {
+      this.context.pop()
+    }
   } else {
     this.unexpected()
   }

--- a/test/tests-template-literal-revision.js
+++ b/test/tests-template-literal-revision.js
@@ -549,3 +549,8 @@ test("foo`\\unicode\\\\`", {
   ],
   sourceType: "script"
 }, {ecmaVersion: 9})
+
+test("`${ {class: 1} }`", {}, { ecmaVersion: 9 })
+test("`${ {delete: 1} }`", {}, { ecmaVersion: 9 })
+test("`${ {enum: 1} }`", {}, { ecmaVersion: 9 })
+test("`${ {function: 1} }`", {}, { ecmaVersion: 9 })


### PR DESCRIPTION
Fixes #575.

In [src/tokencontext.js#L112-L119](https://github.com/ternjs/acorn/blob/9ae70b727426c2f9e9b5aec6cdaaed3657b5ea3a/src/tokencontext.js#L112-L119), `class` and `function` keywords push new context into `this.context`. However, there is no chance to pop the context from `this.context` if the keyword was consumed as an identifier such as `{class: 1}`. This fact breaks the tokenization of template literals.

This PR makes popping the context when a `class`/`function` keyword is consumed as an identifier.

I'm not sure whether this fixing is correct or not. Because this bug is in tokenization process, but this PR modifies parsing process. Please tell me (or feel free to fix it yourself) if the more proper way exists.