### PR TITLE
Fix shorthand properties named `get` or `set` with defaults in object destructuring

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -583,10 +583,11 @@ pp.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos
     prop.kind = "init"
     prop.method = true
     prop.value = this.parseMethod(isGenerator, isAsync)
-  } else if (this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" &&
+  } else if (!isPattern &&
+             this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" &&
              (prop.key.name === "get" || prop.key.name === "set") &&
              (this.type != tt.comma && this.type != tt.braceR)) {
-    if (isGenerator || isAsync || isPattern) this.unexpected()
+    if (isGenerator || isAsync) this.unexpected()
     prop.kind = prop.key.name
     this.parsePropertyName(prop)
     prop.value = this.parseMethod(false)

--- a/src/loose/expression.js
+++ b/src/loose/expression.js
@@ -391,7 +391,7 @@ lp.parseObj = function() {
       prop.value = this.parseMethod(isGenerator, isAsync)
     } else if (this.options.ecmaVersion >= 5 && prop.key.type === "Identifier" &&
                !prop.computed && (prop.key.name === "get" || prop.key.name === "set") &&
-               (this.tok.type != tt.comma && this.tok.type != tt.braceR)) {
+               (this.tok.type != tt.comma && this.tok.type != tt.braceR && this.tok.type != tt.eq)) {
       prop.kind = prop.key.name
       this.parsePropertyName(prop)
       prop.value = this.parseMethod(false)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13402,6 +13402,60 @@ test("var {propName = defaultValue} = obj", {
   locations: true
 });
 
+test("var {get = defaultValue} = obj", {
+  type: "Program",
+  range: [0, 30],
+  body: [{
+    type: "VariableDeclaration",
+    range: [0, 30],
+    declarations: [{
+      type: "VariableDeclarator",
+      range: [4, 30],
+      id: {
+        type: "ObjectPattern",
+        range: [4, 24],
+        properties: [{
+          type: "Property",
+          range: [5, 23],
+          method: false,
+          shorthand: true,
+          computed: false,
+          key: {
+            type: "Identifier",
+            range: [5, 8],
+            name: "get"
+          },
+          kind: "init",
+          value: {
+            type: "AssignmentPattern",
+            range: [5, 23],
+            left: {
+              type: "Identifier",
+              range: [5, 8],
+              name: "get"
+            },
+            right: {
+              type: "Identifier",
+              range: [11, 23],
+              name: "defaultValue"
+            }
+          }
+        }]
+      },
+      init: {
+        type: "Identifier",
+        range: [27, 30],
+        name: "obj"
+      }
+    }],
+    kind: "var"
+  }]
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+});
+
 test("var [localVar = defaultValue] = obj", {
   type: "Program",
   range: [0, 35],


### PR DESCRIPTION
```js
const {get = …} = {}
```

Not sure if the normal parser should use `this.type != tt.eq` to match the loose one, or if you’d prefer a different approach entirely.