### PR TITLE
Fix: `super` is not PrimaryExpression

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -296,12 +296,22 @@ pp.parseExprAtom = function(refDestructuringErrors) {
   case tt._super:
     if (!this.inFunction)
       this.raise(this.start, "'super' outside of function or class")
-
-  case tt._this:
-    let type = this.type === tt._this ? "ThisExpression" : "Super"
     node = this.startNode()
     this.next()
-    return this.finishNode(node, type)
+    // The `super` keyword can appear at below:
+    // SuperProperty:
+    //     super [ Expression ]
+    //     super . IdentifierName
+    // SuperCall:
+    //     super Arguments
+    if (this.type !== tt.dot && this.type !== tt.bracketL && this.type !== tt.parenL)
+      this.unexpected()
+    return this.finishNode(node, "Super")
+
+  case tt._this:
+    node = this.startNode()
+    this.next()
+    return this.finishNode(node, "ThisExpression")
 
   case tt.name:
     let startPos = this.start, startLoc = this.startLoc

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15792,3 +15792,11 @@ test("1 <!--b", {
     }
   }]
 }, {ecmaVersion: 6, sourceType: "module"})
+
+testFail("class A extends B { constructor() { super } }", "Unexpected token (1:42)", { ecmaVersion: 6 })
+testFail("class A extends B { constructor() { super; } }", "Unexpected token (1:41)", { ecmaVersion: 6 })
+testFail("class A extends B { constructor() { (super)() } }", "Unexpected token (1:42)", { ecmaVersion: 6 })
+testFail("class A extends B { foo() { (super).foo } }", "Unexpected token (1:34)", { ecmaVersion: 6 })
+test("({super: 1})", {}, { ecmaVersion: 6 })
+test("import {super as a} from 'a'", {}, { ecmaVersion: 6, sourceType: "module" })
+test("export {a as super}", {}, { ecmaVersion: 6, sourceType: "module" })


### PR DESCRIPTION
This PR makes acorn throwing a syntax error in cases that `super` is a `PrimaryExpression`.

As the spec, the `super` keyword is not `PrimaryExpression`. It can appear in the following productions:

    SuperProperty:
        super [ Expression ]
        super . IdentifierName

    SuperCall:
        super Arguments

So `super` cannot be standalone, and `super` cannot be parenthesized.