### PR TITLE
Update description of ecmaVersion argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ The `bin/acorn` utility can be used to parse a file from the command
 line. It accepts as arguments its input file and the following
 options:
 
-- `--ecma3|--ecma5|--ecma6|--ecma7`: Sets the ECMAScript version to parse. Default is
-  version 5.
+- `--ecma3|--ecma5|--ecma6|--ecma7|--ecma8|--ecma9`: Sets the ECMAScript version
+  to parse. Default is version 7.
 
 - `--module`: Sets the parsing mode to `"module"`. Is set to `"script"` otherwise.
 

--- a/src/bin/acorn.js
+++ b/src/bin/acorn.js
@@ -7,7 +7,7 @@ const options = {}
 
 function help(status) {
   const print = (status == 0) ? console.log : console.error
-  print("usage: " + basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6|--ecma7|...|--ecma2015|--ecma2016|...]")
+  print("usage: " + basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6|--ecma7|--ecma8|--ecma9|...|--ecma2015|--ecma2016|--ecma2017|--ecma2018|...]")
   print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] [infile]")
   process.exit(status)
 }


### PR DESCRIPTION
This is probably not intended to be an exhaustive list, but only leaving out the newest values is counter-intuitive. Also, the documented default is wrong.