### PR TITLE
Check pattern errors only if using expr as pattern

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -115,11 +115,10 @@ pp.parseMaybeAssign = function(noIn, refDestructuringErrors, afterLeftParse) {
   let left = this.parseMaybeConditional(noIn, refDestructuringErrors)
   if (afterLeftParse) left = afterLeftParse.call(this, left, startPos, startLoc)
   if (this.type.isAssign) {
-    this.checkPatternErrors(refDestructuringErrors, true)
-    if (!ownDestructuringErrors) DestructuringErrors.call(refDestructuringErrors)
     let node = this.startNodeAt(startPos, startLoc)
     node.operator = this.value
-    node.left = this.type === tt.eq ? this.toAssignable(left) : left
+    node.left = this.type === tt.eq ? this.toAssignable(left, false, refDestructuringErrors) : left
+    if (!ownDestructuringErrors) DestructuringErrors.call(refDestructuringErrors)
     refDestructuringErrors.shorthandAssign = -1 // reset because shorthand default was used correctly
     this.checkLVal(left)
     this.next()

--- a/src/lval.js
+++ b/src/lval.js
@@ -7,7 +7,7 @@ const pp = Parser.prototype
 // Convert existing expression atom to assignable pattern
 // if possible.
 
-pp.toAssignable = function(node, isBinding) {
+pp.toAssignable = function(node, isBinding, refDestructuringErrors) {
   if (this.options.ecmaVersion >= 6 && node) {
     switch (node.type) {
     case "Identifier":
@@ -22,6 +22,7 @@ pp.toAssignable = function(node, isBinding) {
 
     case "ObjectExpression":
       node.type = "ObjectPattern"
+      if (refDestructuringErrors) this.checkPatternErrors(refDestructuringErrors, true)
       for (let prop of node.properties)
         this.toAssignable(prop, isBinding)
       break
@@ -34,6 +35,7 @@ pp.toAssignable = function(node, isBinding) {
 
     case "ArrayExpression":
       node.type = "ArrayPattern"
+      if (refDestructuringErrors) this.checkPatternErrors(refDestructuringErrors, true)
       this.toAssignableList(node.elements, isBinding)
       break
 
@@ -66,7 +68,7 @@ pp.toAssignable = function(node, isBinding) {
     default:
       this.raise(node.start, "Assigning to rvalue")
     }
-  }
+  } else if (refDestructuringErrors) this.checkPatternErrors(refDestructuringErrors, true)
   return node
 }
 

--- a/src/statement.js
+++ b/src/statement.js
@@ -204,9 +204,8 @@ pp.parseForStatement = function(node) {
   let refDestructuringErrors = new DestructuringErrors
   let init = this.parseExpression(true, refDestructuringErrors)
   if (this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
-    this.toAssignable(init)
+    this.toAssignable(init, false, refDestructuringErrors)
     this.checkLVal(init)
-    this.checkPatternErrors(refDestructuringErrors, true)
     return this.parseForIn(node, init)
   } else {
     this.checkExpressionErrors(refDestructuringErrors, true)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15838,3 +15838,129 @@ test("let instanceof Foo", {
 }, {ecmaVersion: 6})
 
 test("function fn({__proto__: a, __proto__: b}) {}", {}, {ecmaVersion: 6})
+
+testFail('[...foo, bar] = b', "Comma is not permitted after the rest element (1:7)", { ecmaVersion: 6 })
+test('[...a, x][1] = b', {
+  "type": "Program",
+  "start": 0,
+  "end": 16,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 16,
+      "expression": {
+        "type": "AssignmentExpression",
+        "start": 0,
+        "end": 16,
+        "operator": "=",
+        "left": {
+          "type": "MemberExpression",
+          "start": 0,
+          "end": 12,
+          "object": {
+            "type": "ArrayExpression",
+            "start": 0,
+            "end": 9,
+            "elements": [
+              {
+                "type": "SpreadElement",
+                "start": 1,
+                "end": 5,
+                "argument": {
+                  "type": "Identifier",
+                  "start": 4,
+                  "end": 5,
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Identifier",
+                "start": 7,
+                "end": 8,
+                "name": "x"
+              }
+            ]
+          },
+          "property": {
+            "type": "Literal",
+            "start": 10,
+            "end": 11,
+            "value": 1,
+            "raw": "1"
+          },
+          "computed": true
+        },
+        "right": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "name": "b"
+        }
+      }
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 6})
+
+testFail('for (let [...foo, bar] in qux);', "Comma is not permitted after the rest element (1:16)", { ecmaVersion: 6 })
+test('for ([...foo, bar].baz in qux);', {
+  "type": "Program",
+  "start": 0,
+  "end": 31,
+  "body": [
+    {
+      "type": "ForInStatement",
+      "start": 0,
+      "end": 31,
+      "left": {
+        "type": "MemberExpression",
+        "start": 5,
+        "end": 22,
+        "object": {
+          "type": "ArrayExpression",
+          "start": 5,
+          "end": 18,
+          "elements": [
+            {
+              "type": "SpreadElement",
+              "start": 6,
+              "end": 12,
+              "argument": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "name": "foo"
+              }
+            },
+            {
+              "type": "Identifier",
+              "start": 14,
+              "end": 17,
+              "name": "bar"
+            }
+          ]
+        },
+        "property": {
+          "type": "Identifier",
+          "start": 19,
+          "end": 22,
+          "name": "baz"
+        },
+        "computed": false
+      },
+      "right": {
+        "type": "Identifier",
+        "start": 26,
+        "end": 29,
+        "name": "qux"
+      },
+      "body": {
+        "type": "EmptyStatement",
+        "start": 30,
+        "end": 31
+      }
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 6})

--- a/test/tests.js
+++ b/test/tests.js
@@ -27003,7 +27003,7 @@ testFail("--1",
          "Assigning to rvalue (1:2)");
 
 testFail("for((1 + 1) in list) process(x);",
-         "Assigning to rvalue (1:5)");
+         "Parenthesized pattern (1:4)");
 
 testFail("[",
          "Unexpected token (1:1)");


### PR DESCRIPTION
Closes #538. This can also be triggered in assignments like `[...maybeEmptyList, {}][0].first = true` (I couldn't come up with a reasonable use-case yet). I'm not particularly sure about this change, especially the case for `ecmaVersion` < 6, but overall it seems much better from a conceptual point of view.