### PR TITLE
Allow more readNumber productions in sloppy mode

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -29184,6 +29184,22 @@ test("0128", {
   ]
 })
 
+testFail("07.5", "Unexpected token (1:2)")
+
+test("08.5", {
+  "type": "Program",
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "Literal",
+        "value": 8.5,
+        "raw": "08.5"
+      }
+    }
+  ]
+})
+
 test("undefined", {}, { ecmaVersion: 8 })
 
 testFail("\\u{74}rue", "Escape sequence in keyword true (1:0)", {ecmaVersion: 6})


### PR DESCRIPTION
Fixes reading of floating numbers with extra leading zero digit in sloppy mode.

Also simplifies readNumber to just use parseFloat for any decimal numbers.

Fixes #609