### PR TITLE
Simplify unnecessary conditional.

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -198,7 +198,7 @@ pp.checkLVal = function(expr, bindingType, checkClashes) {
     break
 
   case "MemberExpression":
-    if (bindingType) this.raiseRecoverable(expr.start, (bindingType ? "Binding" : "Assigning to") + " member expression")
+    if (bindingType) this.raiseRecoverable(expr.start, "Binding member expression")
     break
 
   case "ObjectPattern":


### PR DESCRIPTION
This fixes the one and only alert flagged by lgtm; cf. https://lgtm.com/projects/g/ternjs/acorn.

(If you'd like to keep the score at zero, our pull request integration can help: https://lgtm.com/docs/lgtm/using-lgtm-analysis-continuous-integration).