### PR TITLE
Improve RestElement, SpreadElement, ObjectPattern and ObjectExpression handling in lval.js

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -17,6 +17,7 @@ pp.toAssignable = function(node, isBinding) {
 
     case "ObjectPattern":
     case "ArrayPattern":
+    case "RestElement":
       break
 
     case "ObjectExpression":
@@ -30,6 +31,11 @@ pp.toAssignable = function(node, isBinding) {
     case "ArrayExpression":
       node.type = "ArrayPattern"
       this.toAssignableList(node.elements, isBinding)
+      break
+
+    case "SpreadElement":
+      node.type = "RestElement"
+      this.toAssignable(node.argument, isBinding)
       break
 
     case "AssignmentExpression":
@@ -64,23 +70,14 @@ pp.toAssignable = function(node, isBinding) {
 
 pp.toAssignableList = function(exprList, isBinding) {
   let end = exprList.length
-  if (end) {
-    let last = exprList[end - 1]
-    if (last && last.type == "RestElement") {
-      --end
-    } else if (last && last.type == "SpreadElement") {
-      last.type = "RestElement"
-      let arg = last.argument
-      this.toAssignable(arg, isBinding)
-      --end
-    }
-
-    if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier")
-      this.unexpected(last.argument.start)
-  }
   for (let i = 0; i < end; i++) {
     let elt = exprList[i]
     if (elt) this.toAssignable(elt, isBinding)
+  }
+  if (end) {
+    let last = exprList[end - 1]
+    if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier")
+      this.unexpected(last.argument.start)
   }
   return exprList
 }

--- a/src/lval.js
+++ b/src/lval.js
@@ -22,10 +22,14 @@ pp.toAssignable = function(node, isBinding) {
 
     case "ObjectExpression":
       node.type = "ObjectPattern"
-      for (let prop of node.properties) {
-        if (prop.kind !== "init") this.raise(prop.key.start, "Object pattern can't contain getter or setter")
-        this.toAssignable(prop.value, isBinding)
-      }
+      for (let prop of node.properties)
+        this.toAssignable(prop, isBinding)
+      break
+
+    case "Property":
+      // AssignmentProperty has type == "Property"
+      if (node.kind !== "init") this.raise(node.key.start, "Object pattern can't contain getter or setter")
+      this.toAssignable(node.value, isBinding)
       break
 
     case "ArrayExpression":
@@ -200,7 +204,12 @@ pp.checkLVal = function(expr, bindingType, checkClashes) {
 
   case "ObjectPattern":
     for (let prop of expr.properties)
-      this.checkLVal(prop.value, bindingType, checkClashes)
+      this.checkLVal(prop, bindingType, checkClashes)
+    break
+
+  case "Property":
+    // AssignmentProperty has type == "Property"
+    this.checkLVal(expr.value, bindingType, checkClashes)
     break
 
   case "ArrayPattern":

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -10592,6 +10592,7 @@ test("function x({ a, b }){}", {
 });
 
 testFail("function x(...[ a, b ]){}", "Unexpected token (1:14)", {ecmaVersion: 6});
+testFail("(([...[ a, b ]]) => {})", "Unexpected token (1:6)", {ecmaVersion: 6});
 
 testFail("function x({ a: { w, x }, b: [y, z] }, ...[a, b, c]){}", "Unexpected token (1:42)", {ecmaVersion: 6});
 


### PR DESCRIPTION
This makes handling of these four node types in `checkLVal` and `toAssignable(List)?` more generic and is a nice preparation for [rest and spread properties](https://github.com/tc39/proposal-object-rest-spread).