### PR TITLE
Remove unused startPos argument from Parser, coding style improvements, new tests

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -43,15 +43,11 @@ pp.toAssignable = function(node, isBinding) {
       break
 
     case "AssignmentExpression":
-      if (node.operator === "=") {
-        node.type = "AssignmentPattern"
-        delete node.operator
-        this.toAssignable(node.left, isBinding)
-        // falls through to AssignmentPattern
-      } else {
-        this.raise(node.left.end, "Only '=' operator can be used for specifying default value.")
-        break
-      }
+      if (node.operator !== "=") this.raise(node.left.end, "Only '=' operator can be used for specifying default value.")
+      node.type = "AssignmentPattern"
+      delete node.operator
+      this.toAssignable(node.left, isBinding)
+      // falls through to AssignmentPattern
 
     case "AssignmentPattern":
       break

--- a/src/statement.js
+++ b/src/statement.js
@@ -358,11 +358,12 @@ pp.parseLabeledStatement = function(node, maybeName, expr) {
   for (let i = this.labels.length - 1; i >= 0; i--) {
     let label = this.labels[i]
     if (label.statementStart == node.start) {
+      // Update information about previous labels on this node
       label.statementStart = this.start
       label.kind = kind
     } else break
   }
-  this.labels.push({name: maybeName, kind: kind, statementStart: this.start})
+  this.labels.push({name: maybeName, kind, statementStart: this.start})
   node.body = this.parseStatement(true)
   if (node.body.type == "ClassDeclaration" ||
       node.body.type == "VariableDeclaration" && node.body.kind != "var" ||
@@ -595,7 +596,8 @@ pp.parseExport = function(node, exports) {
   // export * from '...'
   if (this.eat(tt.star)) {
     this.expectContextual("from")
-    node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected()
+    if (this.type !== tt.string) this.unexpected()
+    node.source = this.parseExprAtom()
     this.semicolon()
     return this.finishNode(node, "ExportAllDeclaration")
   }
@@ -629,7 +631,8 @@ pp.parseExport = function(node, exports) {
     node.declaration = null
     node.specifiers = this.parseExportSpecifiers(exports)
     if (this.eatContextual("from")) {
-      node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected()
+      if (this.type !== tt.string) this.unexpected()
+      node.source = this.parseExprAtom()
     } else {
       // check for keywords used as local names
       for (let spec of node.specifiers) {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -3132,6 +3132,105 @@ test("[a, b] = [b, a]", {
   locations: true
 });
 
+test("[a.r] = b", {
+  "type": "Program",
+  "start": 0,
+  "end": 9,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 9,
+      "expression": {
+        "type": "AssignmentExpression",
+        "start": 0,
+        "end": 9,
+        "operator": "=",
+        "left": {
+          "type": "ArrayPattern",
+          "start": 0,
+          "end": 5,
+          "elements": [
+            {
+              "type": "MemberExpression",
+              "start": 1,
+              "end": 4,
+              "object": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 2,
+                "name": "a"
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 3,
+                "end": 4,
+                "name": "r"
+              },
+              "computed": false
+            }
+          ]
+        },
+        "right": {
+          "type": "Identifier",
+          "start": 8,
+          "end": 9,
+          "name": "b"
+        }
+      }
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 6})
+
+test("let [a,,b] = c", {
+  "type": "Program",
+  "start": 0,
+  "end": 14,
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 14,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 4,
+          "end": 14,
+          "id": {
+            "type": "ArrayPattern",
+            "start": 4,
+            "end": 10,
+            "elements": [
+              {
+                "type": "Identifier",
+                "start": 5,
+                "end": 6,
+                "name": "a"
+              },
+              null,
+              {
+                "type": "Identifier",
+                "start": 8,
+                "end": 9,
+                "name": "b"
+              }
+            ]
+          },
+          "init": {
+            "type": "Identifier",
+            "start": 13,
+            "end": 14,
+            "name": "c"
+          }
+        }
+      ],
+      "kind": "let"
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 6})
+
 test("({ responseText: text } = res)", {
   type: "Program",
   body: [{
@@ -6762,6 +6861,64 @@ test("class A { static *gen(v) { yield v; }}", {
   ranges: true,
   locations: true
 });
+
+testFail("(class { *static x() {} })", "Unexpected token (1:17)", {ecmaVersion: 6});
+test("(class { *static() {} })", {
+  "type": "Program",
+  "start": 0,
+  "end": 24,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 24,
+      "expression": {
+        "type": "ClassExpression",
+        "start": 1,
+        "end": 23,
+        "id": null,
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 7,
+          "end": 23,
+          "body": [
+            {
+              "type": "MethodDefinition",
+              "start": 9,
+              "end": 21,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 10,
+                "end": 16,
+                "name": "static"
+              },
+              "static": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 16,
+                "end": 21,
+                "id": null,
+                "generator": true,
+                "expression": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 19,
+                  "end": 21,
+                  "body": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 6});
 
 test("\"use strict\"; (class A {constructor() { super() }})", {
   type: "Program",
@@ -10595,6 +10752,7 @@ testFail("function x(...[ a, b ]){}", "Unexpected token (1:14)", {ecmaVersion: 6
 testFail("(([...[ a, b ]]) => {})", "Unexpected token (1:6)", {ecmaVersion: 6});
 
 testFail("function x({ a: { w, x }, b: [y, z] }, ...[a, b, c]){}", "Unexpected token (1:42)", {ecmaVersion: 6});
+testFail("(function ({ a(){} }) {})", "Unexpected token (1:14)", {ecmaVersion: 6});
 
 test("(function x([ a, b ]){})", {
   type: "Program",
@@ -13744,6 +13902,8 @@ testFail("obj = {x = 0}", "Shorthand property assignments are valid only in dest
 
 testFail("f({x = 0})", "Shorthand property assignments are valid only in destructuring patterns (1:5)", {ecmaVersion: 6});
 
+testFail("(localVar |= defaultValue) => {}", "Only '=' operator can be used for specifying default value. (1:9)", {loose: false, ecmaVersion: 6});
+
 // https://github.com/ternjs/acorn/issues/191
 
 test("try {} catch ({message}) {}", {
@@ -15648,6 +15808,8 @@ test("export { default as y } from './y.js';\nexport default 42;",
 testFail("export { default} from './y.js';\nexport default 42;",
          "Duplicate export 'default' (2:7)",
          {sourceType: "module", ecmaVersion: 6})
+testFail("export * from foo", "Unexpected token (1:14)", {sourceType: "module", ecmaVersion: 6, loose: false});
+testFail("export { bar } from foo", "Unexpected token (1:20)", {sourceType: "module", ecmaVersion: 6, loose: false});
 
 testFail("foo: class X {}", "Invalid labeled declaration (1:5)", {ecmaVersion: 6})
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -20720,6 +20720,57 @@ test("done: while (true) { break done; }", {
   }
 });
 
+test("done: switch (a) { default: break done }", {
+  "type": "Program",
+  "start": 0,
+  "end": 40,
+  "body": [
+    {
+      "type": "LabeledStatement",
+      "start": 0,
+      "end": 40,
+      "body": {
+        "type": "SwitchStatement",
+        "start": 6,
+        "end": 40,
+        "discriminant": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "name": "a"
+        },
+        "cases": [
+          {
+            "type": "SwitchCase",
+            "start": 19,
+            "end": 38,
+            "consequent": [
+              {
+                "type": "BreakStatement",
+                "start": 28,
+                "end": 38,
+                "label": {
+                  "type": "Identifier",
+                  "start": 34,
+                  "end": 38,
+                  "name": "done"
+                }
+              }
+            ],
+            "test": null
+          }
+        ]
+      },
+      "label": {
+        "type": "Identifier",
+        "start": 0,
+        "end": 4,
+        "name": "done"
+      }
+    }
+  ]
+});
+
 test("target1: target2: while (true) { continue target1; }", {});
 test("target1: target2: target3: while (true) { continue target1; }", {});
 
@@ -26387,6 +26438,55 @@ test("foo: if (true) break foo;", {
   ]
 });
 
+test("a: { b: switch(x) {} }", {
+  "type": "Program",
+  "start": 0,
+  "end": 22,
+  "body": [
+    {
+      "type": "LabeledStatement",
+      "start": 0,
+      "end": 22,
+      "body": {
+        "type": "BlockStatement",
+        "start": 3,
+        "end": 22,
+        "body": [
+          {
+            "type": "LabeledStatement",
+            "start": 5,
+            "end": 20,
+            "body": {
+              "type": "SwitchStatement",
+              "start": 8,
+              "end": 20,
+              "discriminant": {
+                "type": "Identifier",
+                "start": 15,
+                "end": 16,
+                "name": "x"
+              },
+              "cases": []
+            },
+            "label": {
+              "type": "Identifier",
+              "start": 5,
+              "end": 6,
+              "name": "b"
+            }
+          }
+        ]
+      },
+      "label": {
+        "type": "Identifier",
+        "start": 0,
+        "end": 1,
+        "name": "a"
+      }
+    }
+  ]
+});
+
 test("(function () {\n 'use strict';\n '\0';\n}())", {
   type: "Program",
   loc: {
@@ -27511,7 +27611,11 @@ testFail("for(const x = 0;;);", "The keyword 'const' is reserved (1:4)");
 
 testFail("for(let x = 0;;);", "Unexpected token (1:8)");
 
-testFail("function a(b = c) {}", "Unexpected token (1:13)")
+testFail("function a(b = c) {}", "Unexpected token (1:13)");
+
+testFail("switch (x) { something }", "Unexpected token (1:13)");
+
+testFail("`abc`", "Unexpected character '`' (1:0)", {ecmaVersion: 5});
 
 test("let++", {
   type: "Program",


### PR DESCRIPTION
I looked at the test suite's code coverage and found it's quite good, around 95% depending on the metric. However, I found that the `startPos` argument to `Parser` is unused. I also stumbled across weird conditionals: two where `this.unexpected()` was called in a ternery and one with a `break` after an `this.raise()` call. And I added test cases for non-covered code paths.