### PR TITLE
Add `s` (dotAll) flag for regular expressions

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -408,6 +408,7 @@ pp.readRegexp = function() {
   if (mods) {
     let validFlags = /^[gim]*$/
     if (this.options.ecmaVersion >= 6) validFlags = /^[gimuy]*$/
+    if (this.options.ecmaVersion >= 9) validFlags = /^[gimsuy]*$/
     if (!validFlags.test(mods)) this.raise(start, "Invalid regular expression flag")
     if (mods.indexOf("u") >= 0) {
       if (regexpUnicodeSupport) {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -14740,6 +14740,29 @@ test("/[a-z]/gimuy", {
   ]
 }, {ecmaVersion: 6});
 testFail("/[a-z]/s", "Invalid regular expression flag (1:1)", {ecmaVersion: 6});
+test("/[a-z]/s", {
+  "type": "Program",
+  "start": 0,
+  "end": 8,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 8,
+      "expression": {
+        "type": "Literal",
+        "start": 0,
+        "end": 8,
+        "raw": "/[a-z]/s",
+        "regex": {
+          "pattern": "[a-z]",
+          "flags": "s"
+        }
+      }
+    }
+  ],
+  "sourceType": "script"
+}, {ecmaVersion: 9});
 
 testFail("[...x in y] = []", "Assigning to rvalue (1:4)", {ecmaVersion: 6});
 


### PR DESCRIPTION
Closes #631. Is ECMAScript version 9 correct?