### PR TITLE
Extract parseClassMember

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -530,40 +530,45 @@ pp.parseClass = function(node, isStatement) {
 
 pp.parseClassMember = function(classBody) {
   let method = this.startNode()
+
+  const tryContextual = (k, noLineBreak = false) => {
+    const start = this.start, startLoc = this.startLoc
+    if (!this.eatContextual(k)) return false
+    if (this.type !== tt.parenL && (!noLineBreak || !this.canInsertSemicolon())) return true
+    if (method.key) this.unexpected()
+    method.computed = false
+    method.key = this.startNodeAt(start, startLoc)
+    method.key.name = k
+    this.finishNode(method.key, "Identifier")
+    return false
+  }
+
+  method.kind = "method"
+  method.static = tryContextual("static")
   let isGenerator = this.eat(tt.star)
   let isAsync = false
-  let isMaybeStatic = this.type === tt.name && this.value === "static"
-  this.parsePropertyName(method)
-  method.static = isMaybeStatic && this.type !== tt.parenL
-  if (method.static) {
-    if (isGenerator) this.unexpected()
-    isGenerator = this.eat(tt.star)
-    this.parsePropertyName(method)
-  }
-  if (this.options.ecmaVersion >= 8 && !isGenerator && !method.computed &&
-      method.key.type === "Identifier" && method.key.name === "async" && this.type !== tt.parenL &&
-      !this.canInsertSemicolon()) {
-    isAsync = true
-    this.parsePropertyName(method)
-  }
-  method.kind = "method"
   let isGetSet = false
-  if (!method.computed) {
-    let {key} = method
-    if (!isGenerator && !isAsync && key.type === "Identifier" && this.type !== tt.parenL && (key.name === "get" || key.name === "set")) {
+  if (!isGenerator) {
+    if (this.options.ecmaVersion >= 8 && tryContextual("async", true)) {
+      isAsync = true
+    } else if (tryContextual("get")) {
       isGetSet = true
-      method.kind = key.name
-      key = this.parsePropertyName(method)
+      method.kind = "get"
+    } else if (tryContextual("set")) {
+      isGetSet = true
+      method.kind = "set"
     }
-    if (!method.computed && !method.static && (key.type === "Identifier" && key.name === "constructor" ||
-        key.type === "Literal" && key.value === "constructor")) {
-      if (isGetSet) this.raise(key.start, "Constructor can't have get/set modifier")
-      if (isGenerator) this.raise(key.start, "Constructor can't be a generator")
-      if (isAsync) this.raise(key.start, "Constructor can't be an async method")
-      method.kind = "constructor"
-    } else if (method.static && key.type === "Identifier" && key.name === "prototype") {
-      this.raise(key.start, "Classes may not have a static property named prototype")
-    }
+  }
+  if (!method.key) this.parsePropertyName(method)
+  let {key} = method
+  if (!method.computed && !method.static && (key.type === "Identifier" && key.name === "constructor" ||
+      key.type === "Literal" && key.value === "constructor")) {
+    if (isGetSet) this.raise(key.start, "Constructor can't have get/set modifier")
+    if (isGenerator) this.raise(key.start, "Constructor can't be a generator")
+    if (isAsync) this.raise(key.start, "Constructor can't be an async method")
+    method.kind = "constructor"
+  } else if (method.static && key.type === "Identifier" && key.name === "prototype") {
+    this.raise(key.start, "Classes may not have a static property named prototype")
   }
   this.parseClassMethod(classBody, method, isGenerator, isAsync)
   if (isGetSet) {

--- a/src/statement.js
+++ b/src/statement.js
@@ -547,15 +547,12 @@ pp.parseClassMember = function(classBody) {
   method.static = tryContextual("static")
   let isGenerator = this.eat(tt.star)
   let isAsync = false
-  let isGetSet = false
   if (!isGenerator) {
     if (this.options.ecmaVersion >= 8 && tryContextual("async", true)) {
       isAsync = true
     } else if (tryContextual("get")) {
-      isGetSet = true
       method.kind = "get"
     } else if (tryContextual("set")) {
-      isGetSet = true
       method.kind = "set"
     }
   }
@@ -563,7 +560,7 @@ pp.parseClassMember = function(classBody) {
   let {key} = method
   if (!method.computed && !method.static && (key.type === "Identifier" && key.name === "constructor" ||
       key.type === "Literal" && key.value === "constructor")) {
-    if (isGetSet) this.raise(key.start, "Constructor can't have get/set modifier")
+    if (method.kind !== "method") this.raise(key.start, "Constructor can't have get/set modifier")
     if (isGenerator) this.raise(key.start, "Constructor can't be a generator")
     if (isAsync) this.raise(key.start, "Constructor can't be an async method")
     method.kind = "constructor"
@@ -571,19 +568,12 @@ pp.parseClassMember = function(classBody) {
     this.raise(key.start, "Classes may not have a static property named prototype")
   }
   this.parseClassMethod(classBody, method, isGenerator, isAsync)
-  if (isGetSet) {
-    let paramCount = method.kind === "get" ? 0 : 1
-    if (method.value.params.length !== paramCount) {
-      let start = method.value.start
-      if (method.kind === "get")
-        this.raiseRecoverable(start, "getter should have no params")
-      else
-        this.raiseRecoverable(start, "setter should have exactly one param")
-    } else {
-      if (method.kind === "set" && method.value.params[0].type === "RestElement")
-        this.raiseRecoverable(method.value.params[0].start, "Setter cannot use rest params")
-    }
-  }
+  if (method.kind === "get" && method.value.params.length !== 0)
+    this.raiseRecoverable(method.value.start, "getter should have no params")
+  if (method.kind === "set" && method.value.params.length !== 1)
+    this.raiseRecoverable(method.value.start, "setter should have exactly one param")
+  if (method.kind === "set" && method.value.params[0].type === "RestElement")
+    this.raiseRecoverable(method.value.params[0].start, "Setter cannot use rest params")
   return method
 }
 

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -7072,7 +7072,7 @@ test("class A {'constructor'() {}}", {
   }]
 }, {ecmaVersion: 6});
 
-testFail("class A { constructor() {} 'constructor'() }", "Duplicate constructor in the same class (1:27)", {ecmaVersion: 6});
+testFail("class A { constructor() {} 'constructor'() {} }", "Duplicate constructor in the same class (1:27)", {ecmaVersion: 6});
 
 testFail("class A { get constructor() {} }", "Constructor can't have get/set modifier (1:14)", {ecmaVersion: 6});
 test("class A { get ['constructor']() {} }", {


### PR DESCRIPTION
See #639.

The first commit seems to be the minimum necessary to allow easy implementation of decorators, class fields and private class members.

The second commit is an attempt to switch `parseClassMember` from using `parsePropertyName` for parsing `async`, `set`, `get` and `static` to something more straight-forward.